### PR TITLE
 Allows Kaspafisto, Oficiro, and Veterano to be female/use the fembodysprite

### DIFF
--- a/code/modules/jobs/job_types/roguetown/risvonian/kaspafisto.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/kaspafisto.dm
@@ -6,7 +6,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	allowed_races = RACES_CONSCRIPT
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 
 	tutorial = "You've walked down the path of Zipra, earning a promotion from Tuoro to become a Kaspafisto. \

--- a/code/modules/jobs/job_types/roguetown/risvonian/oficiro.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/oficiro.dm
@@ -6,7 +6,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	allowed_races = RACES_CONSCRIPT
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 
 	tutorial = "You're a Risvonian military officer. \

--- a/code/modules/jobs/job_types/roguetown/risvonian/veterano.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/veterano.dm
@@ -6,7 +6,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	allowed_races = RACES_CONSCRIPT
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 
 	tutorial = "You're Risvonian Squad Support. \


### PR DESCRIPTION
## About The Pull Request

Allows Kaspafisto, Oficiro, and Veterano to be female/use the fembodysprite
Their equipment is compatible, and with the Risvonian lore rewrite, making the faction follow a might-makes right egalitarian ideology, ("Essentially an empire where it doesnt matter who you are, it only matters if you manage to take power.") I think these roles should be Unisex. (Technically Tuoro's equipment is also fembodysprite compatible but I think someone who lugs a giant shield around should not be a dainty femme.)

## Testing Evidence
<img width="1238" height="692" alt="Screenshot 2026-04-06 220145" src="https://github.com/user-attachments/assets/efd89cb4-cb64-4481-8173-c21df5373911" />

<img width="692" height="527" alt="Screenshot 2026-04-06 220202" src="https://github.com/user-attachments/assets/53abc10d-cc8d-4bef-b0dd-4267d3c0c0bb" />

## Why It's Good For The Game
More character diversity, making the game more accurate to new lore