### PR TITLE
Adds clickdelay to rifle racking

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -89,6 +89,8 @@
 	///Whether the gun can be tacloaded by slapping a fresh magazine directly on it
 	var/tac_reloads = TRUE //Snowflake mechanic no more.
 	var/verbage = "load"
+	//Whether or not racking has a click delay
+	var/slamfire = FALSE
 
 /obj/item/gun/ballistic/Initialize()
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -66,7 +66,9 @@
 	if(HAS_TRAIT(user, TRAIT_FIREARMS_EXPERT)) //unused as of rn
 		recentpump = world.time + 2
 	else
-		recentpump = world.time + 10
+		recentpump = world.time + 8
+	if(!slamfire)
+		user.changeNext_move(CLICK_CD_FAST)
 
 /obj/item/gun/ballistic/rifle/proc/pump(mob/M, visible = TRUE)
 	if(visible)
@@ -188,6 +190,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/leverchester
 	slowdown = 0.15
 	spread = 0.5
+	slamfire = TRUE
 	pump_sound = 'sound/combat/ranged/leveractioncock.ogg'
 	fire_sound = REVOLVERSHOT
 	load_sound = 'sound/combat/ranged/leveractioninsert.ogg'


### PR DESCRIPTION
## About The Pull Request
title
.8 second delay between each shot if you are perfect
only effects rifles
the lever action rifle doesnt have this
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/6a489abe-b48f-4466-816a-b087091387e1

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bolt-action rifles cannot be shot as fast as you can click anymore
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
