### PR TITLE
Surrendering slows bleeding + Con affects bleeding

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -168,7 +168,14 @@
 		return FALSE
 	if(blood_volume <= 0)
 		return FALSE
-	
+	var/conbonus = 1
+	if(STACON >= 15)
+		conbonus = 15 - 10
+	else if(STACON != 10)
+		conbonus = STACON - 10
+	amt -= amt * (conbonus * 0.1)
+	if(surrendering)
+		amt = amt / 4 // Helps yield condition not be a bloodloss failure state. 
 	blood_volume = max(blood_volume - amt, 0)
 	GLOB.azure_round_stats[STATS_BLOOD_SPILT] += amt
 	if(isturf(src.loc)) //Blood loss still happens in locker, floor stays clean


### PR DESCRIPTION
## About The Pull Request
Con now slows or speeds up bleeding depending on how far you are from ten. Surrendering makes it so that as long as you're still surrendering you bleed a quarter as fast as normal.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I tested the surrendering stuff, but not the con stuff. It probably works! It's just the Azure Peak code but changed to be static numbers instead of definitions we don't have.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Surrendering as-is is a blood loss fail state. That kinda sucks. Also, con does more stuff.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
