### PR TITLE
Fixes Shrapnel + Frag Grenade buffs

### DIFF
--- a/code/datums/components/shrapnel.dm
+++ b/code/datums/components/shrapnel.dm
@@ -1,27 +1,9 @@
-/datum/component/shrapnel
+/obj/effect/shrapnel
 	var/projectile_type
 	var/radius // shoots a projectile for every turf on this radius from the hit target
 	var/override_projectile_range
 
-/datum/component/shrapnel/Initialize(projectile_type, radius=1, override_projectile_range)
-	if(!isgun(parent) && !ismachinery(parent) && !isstructure(parent))
-		return COMPONENT_INCOMPATIBLE
-
-	src.projectile_type = projectile_type
-	src.radius = radius
-	src.override_projectile_range = override_projectile_range
-
-/datum/component/shrapnel/RegisterWithParent()
-	if(ismachinery(parent) || isstructure(parent) || isgun(parent)) // turrets, etc
-		RegisterSignal(parent, COMSIG_PROJECTILE_ON_HIT, PROC_REF(projectile_hit))
-
-/datum/component/shrapnel/UnregisterFromParent()
-	UnregisterSignal(parent, list(COMSIG_PROJECTILE_ON_HIT))
-
-/datum/component/shrapnel/proc/projectile_hit(atom/fired_from, atom/movable/firer, atom/target, Angle)
-	do_shrapnel(firer, target)
-
-/datum/component/shrapnel/proc/do_shrapnel(mob/firer, atom/target)
+/obj/effect/shrapnel/proc/do_shrapnel(mob/firer, atom/target)
 	if(radius < 1)
 		return
 	var/turf/target_turf = get_turf(target)
@@ -36,7 +18,7 @@
 		P.firer = firer // don't hit ourself that would be really annoying
 		P.def_zone = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)
 		P.permutated += target // don't hit the target we hit already with the flak
-		for(var/mob/living/M in target.loc)//if you're on the tile bad things happen
+		for(var/mob/living/M in target)//if you're on the tile bad things happen
 			if(M.lying && isturf(firer.loc))//good luck with your saving private ryan move
 				if(rand(1,100) >= 10)
 					P.original = M
@@ -57,3 +39,4 @@
 					qdel(P)
 		if (P.shouldfire == TRUE)
 			P.fire()
+	qdel(src)

--- a/code/game/objects/items/explosives/grenades.dm
+++ b/code/game/objects/items/explosives/grenades.dm
@@ -95,16 +95,27 @@
 	name = "'Molon Labe' fragmentation grenade"
 	desc = "Four seconds. A lumpy shaped shrapnel shitter. Take care not to hit yourself."
 	icon_state = "pineapple-nade"
-	fuze = 40
+	fuze = 25
 	var/fradius = 6
 
 //frag explode
 /obj/item/grenade/frag/explode()
 	visible_message(span_danger("[src] explodes!"))
-	var/datum/component/shrapnel/fragnade = new /datum/component/shrapnel()
+	var/obj/effect/shrapnel/uwu
+	uwu = new /obj/effect/shrapnel()
 	var/target = get_turf(src)
-	fragnade.projectile_type = /obj/projectile/bullet/shrapnel
-	fragnade.radius = fradius	
-	fragnade.do_shrapnel(src, target)
+	uwu.projectile_type = /obj/projectile/bullet/shrapnel
+	uwu.radius = fradius
+	uwu.do_shrapnel(src, target)
 	explosion(src, devastation_range = 0, heavy_impact_range = 1, light_impact_range = 1, flash_range = 0, smoke = FALSE, soundin = pick('sound/misc/explode/arty1.ogg','sound/misc/explode/arty2.ogg','sound/misc/explode/arty3.ogg','sound/misc/explode/arty4.ogg','sound/misc/explode/arty5.ogg','sound/misc/explode/arty6.ogg'))
 	qdel(src)
+
+/*
+	var/obj/effect/shrapnel/uwu //it's my code and i get to name the variables what i want
+	uwu = new /obj/effect/shrapnel()
+	var target = get_turf(src)
+	uwu.projectile_type = /obj/projectile/bullet/shrapnel/frogmine
+	uwu.radius = 5
+	uwu.override_projectile_range = 10	
+	uwu.do_shrapnel(src, target)
+*/

--- a/code/modules/projectiles/projectile/general.dm
+++ b/code/modules/projectiles/projectile/general.dm
@@ -92,8 +92,8 @@
 
 /obj/projectile/bullet/shrapnel //default shrapnel; if we ever want specific behaviors for shrapnel we can put em here
 	name = "pellet"
-	damage = 30
-	armor_penetration = 40
+	damage = 70
+	armor_penetration = 20
 	hitscan = FALSE
 	ignore_source_check = TRUE
 	woundclass = BCLASS_CUT

--- a/modular_temperance/code/game/objects/effects/mines.dm
+++ b/modular_temperance/code/game/objects/effects/mines.dm
@@ -72,11 +72,12 @@
 	playsound(get_turf(src), 'modular_temperance/sounds/misc/frogmine_leap.ogg', 60, FALSE)
 	sleep(mine_delay)
 	visible_message(span_danger("[src] explodes!"))
-	var/datum/component/shrapnel/frogmine_shrapnel = new /datum/component/shrapnel()
+	var/obj/effect/shrapnel/uwu //it's my code and i get to name the variables what i want
+	uwu = new /obj/effect/shrapnel()
 	var target = get_turf(src)
-	frogmine_shrapnel.projectile_type = /obj/projectile/bullet/shrapnel/frogmine
-	frogmine_shrapnel.radius = 5
-	frogmine_shrapnel.override_projectile_range = 10	
-	frogmine_shrapnel.do_shrapnel(src, target)
+	uwu.projectile_type = /obj/projectile/bullet/shrapnel/frogmine
+	uwu.radius = 5
+	uwu.override_projectile_range = 10	
+	uwu.do_shrapnel(src, target)
 	explosion(src, devastation_range = 0, heavy_impact_range = 1, light_impact_range = 1, flash_range = 0, smoke = TRUE, soundin = pick('sound/misc/explode/arty1.ogg','sound/misc/explode/arty2.ogg','sound/misc/explode/arty3.ogg','sound/misc/explode/arty4.ogg','sound/misc/explode/arty5.ogg','sound/misc/explode/arty6.ogg'))
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request
Frag grenades go off faster- more like 5 seconds instead of 8, now. They also do more damage, ESPECIALLY to parts without armor. 

However, THAT isn't the important thing! The important thing is- rewrites all of the shrapnel code so it NO LONGER RUNTIMES! AND DOESN'T STOP SPEWING OUT SHRAPNEL RANDOMLY!

Turns out, the existing shrapnel code was so you could shoot something like a machine and it'd spew out shrapnel after. We can probably add it back later if we want this. But Ratwood misused it! May they rot, truly.

Also, my code was checking the entire _area_ for people standing on the same tile, and as a result, if you had a lot of people in an area (i.e king's row) it wouldn't fire any shrapnel since it tries to fire it all early due to someone on the 'same turf'.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I tested it and it no runtime :D
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Game work better. Also, grenades should be pretty effective.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
