### PR TITLE
Removes high-tier automatics from the drop pool

### DIFF
--- a/code/game/objects/effects/spawners/loot_spawners.dm
+++ b/code/game/objects/effects/spawners/loot_spawners.dm
@@ -428,12 +428,9 @@
 	icon_state = "highgun"
 	lootcount = 1
 	loot = list(
-		/obj/item/gun/ballistic/shotgun/eternal = 1,
+		/obj/item/gun/ballistic/shotgun/eternal = 5,
 		/obj/item/gun/ballistic/rifle/repeater/patience	= 1,
-		/obj/item/gun/ballistic/rifle/reaper = 1,
-		/obj/item/gun/ballistic/rifle/repeater/mondragon = 1,
-		/obj/item/gun/ballistic/rifle/repeater/mpcolt = 1,
-	)
+		/obj/item/gun/ballistic/rifle/reaper = 5,	)
 
 /obj/effect/spawner/lootdrop/normalguns
 	name = "normal gun spawner"
@@ -457,7 +454,6 @@
 	loot = list(
 		/obj/item/ammo_box/boxes/amr = 1,
 		/obj/item/ammo_box/clip/reaper = 3,
-		/obj/item/ammo_box/magazine/cfmag = 2,
 	)
 
 /obj/effect/spawner/lootdrop/ammo


### PR DESCRIPTION
## About The Pull Request
Removes the Mondragon and MPcolt, makes the AMR a lot rarer. Reaper can stay, per Zera.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
it works probably
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
High-tier automatics causing severe power creep in guns; if you're using a bolt action comes the War, you're going to get slaughtered. Plus, I can use some of these for other stuff, like the Auto-5.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
