### PR TITLE
makes roles not appearing in latejoin appear in latejoin

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -199,6 +199,7 @@ GLOBAL_LIST_INIT(risvon_positions, list(
 	"Kaspafisto",
 	"Veterano",
 	"Soldato",
+	"Magiisto",
 	"Bastiono",
 	"Armilteknikisto",
 	"Municioteknikisto",
@@ -212,6 +213,7 @@ GLOBAL_LIST_INIT(kingsrow_positions, list(
 	"Hierarch",
 	"Bulwark",
 	"Provisioner",
+	"Barkeeper",
 	"Towner",
 	"Mortician",
 ))

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -203,7 +203,6 @@ GLOBAL_LIST_INIT(risvon_positions, list(
 	"Bastiono",
 	"Armilteknikisto",
 	"Municioteknikisto",
-	"Servisto",
 	"Curacisto",
 	"Camp Follower",
 	"Consulo",

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -196,8 +196,10 @@ GLOBAL_LIST_INIT(perserdun_positions, list(
 GLOBAL_LIST_INIT(risvon_positions, list(
 	"Commandant",
 	"Oficiro",
+	"Kaspafisto",
 	"Veterano",
 	"Soldato",
+	"Bastiono",
 	"Armilteknikisto",
 	"Municioteknikisto",
 	"Servisto",


### PR DESCRIPTION
## About The Pull Request
on tonight's episode of tope code

i fuck up the shrapnel component and almost crash the game
jamie makes the auto 8 a regular spawn in dungeons
and hammond forgets to add the new roles to jobs.dm
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
(fixes new roles so you can latejoin as them)
## Testing Evidence
i pressa da button for bastiono and it work
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
game work good. game no work bad
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
