### PR TITLE
Inventory Storage Delay Removed From Knives/Swords

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -107,7 +107,6 @@
 
 	equip_delay_self = 1 SECONDS
 	unequip_delay_self = 1 SECONDS
-	inv_storage_delay = 1 SECONDS
 	edelay_type = 1
 
 	//flipping knives has a cooldown on to_chat to reduce chatspam

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -141,7 +141,6 @@
 
 	equip_delay_self = 1.5 SECONDS
 	unequip_delay_self = 1.5 SECONDS
-	inv_storage_delay = 1.5 SECONDS
 	edelay_type = 1
 
 /obj/item/rogueweapon/sword/Initialize()


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
History Lesson:

Lifeweb had sheaths. The purpose of sheaths was that they would let you carry swords on your belt slot without them falling off randomly when you moved.

Roguetown came later, and had sheaths. You could already put swords on your belt without them falling off randomly so they were more of a flavour thing.

Present Day:
Some genius at azure peak/ratwood decides that it's unbalanced to be able to simply store knives in your satchel and remove them at will. Their solution is to add "knife sheaths" that let you instantly take and store knives from your satchel, then they slapped a move_after() onto them and called that 'balance'. As a result they had to add a wholly new and redundant item to EVERY role that spawned with a knife in their bag just to justify the existence of knife sheaths. 

Part of the reason this is crazy is that it is literally not even a problem. But I digress.

This PR removes that annoying delay. That's all it does. Let us not suffer the imbecilic decisions of others. 
I have left equip delays untouched because literally everything has them and I don't want to bother poring over every single equip delay in this game. 
## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
It just works. 


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
This is literally a QoL change because most roles don't even spawn with knife sheathes. This is because no sane man would ever forsee this being a 'feature' in the first place. In real life it makes sense to have a sheath for your knife. This is a videogame where in order to access your inventory you have to stop in place and THEN give whatever a look. 