### PR TITLE
Reworks the 'Actors' list to be grouped by faction

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1633,3 +1633,36 @@ GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 			for(var/atom/contained_atom in M.component_parts)
 				contained_atom.flags_1 |= HOLOGRAM_1
 	return O
+
+/proc/get_actors_by_title(var/title)
+	var/list/actor_data = list()
+	for(var/mob_id in GLOB.actors_list)
+		if(GLOB.actors_list[mob_id]["rank"] != title)
+			continue
+		actor_data += list(list(
+			"data" = GLOB.actors_list[mob_id],
+			"mob_id" = mob_id,
+		))
+	return actor_data
+
+/proc/get_sorted_actors_list()
+	var/list/sorted_ckey_to_actor_data = list()
+	var/list/categories = list(
+		"Perserdun" = GLOB.perserdun_positions,
+		"Risvon" = GLOB.risvon_positions,
+		"King's Row" = GLOB.kingsrow_positions,
+		"Nobody" = GLOB.nonaffiliated_positions,
+	)
+
+	for(var/category in categories)
+		for(var/role in categories[category])
+			var/list/actor_data = get_actors_by_title(role)
+			for(var/actor in actor_data)
+				sorted_ckey_to_actor_data[actor["mob_id"]] = list("data" = actor["data"], "category" = category)
+
+	for(var/mob_id in GLOB.actors_list)
+		var/list/actor_data = GLOB.actors_list[mob_id]
+		if(!sorted_ckey_to_actor_data[mob_id])
+			sorted_ckey_to_actor_data[mob_id] = list("data" = actor_data, "category" = "Nobodies")
+
+	return sorted_ckey_to_actor_data

--- a/code/modules/client/roundendmanifest.dm
+++ b/code/modules/client/roundendmanifest.dm
@@ -9,11 +9,33 @@
 	popup.open(FALSE)
 
 /client/proc/view_actors_manifest()
+	var/list/actors_list = get_sorted_actors_list()
+	var/list/categories_used = list()
 	var/dat
-	for(var/X in GLOB.actors_list)
-		dat += "[GLOB.actors_list[X]]"
+	var/list/categories = list(
+		"Perserdun" = GLOB.perserdun_positions,
+		"Risvon" = GLOB.risvon_positions,
+		"King's Row" = GLOB.kingsrow_positions,
+		"Nobody" = GLOB.nonaffiliated_positions,
+	)
 
-	var/datum/browser/popup = new(src, "actors", "<center>This Story's Actors</center>", 387, 420)
+	for(var/mob_id in actors_list)
+		var/list/actor_data = actors_list[mob_id]
+		var/category = actor_data["category"] //Gets the actor's cateogry and puts it in 'category' for us
+
+		if(!(category in categories_used))
+			var/cat_color = COLOR_WHITE
+			if(length(categories_used))
+				dat += "<br>"
+			if(category in categories)
+				var/current_category = categories[category]
+				cat_color = SSjob.name_occupations[current_category[1]].selection_color
+			dat += "<center><h1 style='padding-top: 0; bold; color: [cat_color]'>-- [category] --</h1></center>"
+			categories_used += category
+		var/list/character_data = actor_data["data"]
+		dat += "<b>[character_data["name"]]</b> as <b>[character_data["rank"]]</b><br>"
+
+	var/datum/browser/popup = new(src, "actors", "<center>This Battle's Victims</center>", 387, 420)
 	popup.set_content(dat)
 	popup.open(FALSE)
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -227,10 +227,15 @@
 		H.cmode_music = cmode_music
 
 	if (!hidden_job)
+		var/mob_name = H.real_name
+		var/mob_rank
 		if (obsfuscated_job)
-			GLOB.actors_list[H.mobid] = "[H.real_name] as Adventurer<BR>"
+			mob_rank = "Adventurer"
 		else
-			GLOB.actors_list[H.mobid] = "[H.real_name] as [H.mind.assigned_role]<BR>"
+			mob_rank = H.mind.assigned_role
+		GLOB.actors_list[H.mobid] = list("name" = mob_name, "rank" = mob_rank)
+		
+	log_admin("[H.key]/([H.real_name]) has joined as [H.mind.assigned_role].")
 
 /client/verb/set_mugshot()
 	set category = "OOC"


### PR DESCRIPTION
## About The Pull Request
Reworks the manifest- or 'Actors' list- to be grouped by faction instead. Faction colors determined by the selection color of the first role in the faction.

Should be a nice QoL, mostly just ported from azure peak.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="386" height="416" alt="image" src="https://github.com/user-attachments/assets/8b16aecc-06f9-41ef-afdd-a50464c46fa7" />
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Pretty stuff to help tell which side has more goons.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
