### PR TITLE
Removes the Auto-5 from the Provisioner

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/t13/guns.dm
+++ b/code/modules/cargo/packsrogue/merchant/t13/guns.dm
@@ -107,10 +107,3 @@
 	contains = list(
 					/obj/item/gun/ballistic/rifle/repeater/risvocarb,
 				)
-
-/datum/supply_pack/rogue/firearms/auto5
-	name = "AO5 'Gloria' Semi-Automatic Shotgun"
-	cost = 300
-	contains = list(
-					/obj/item/gun/ballistic/rifle/repeater/auto5,
-				)


### PR DESCRIPTION
## About The Pull Request
Just makes it so you can't buy the Auto-5 from the Provisioner.

That's it. Was gonna throw this into my new role PR but figured I should atomize it in case the new role PR gets refused.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It compiled and I couldn't be bothered to boot up and test
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The Auto-5 is WAY too good even for 300. you're more or less turning a regular soldier into a power role every time you buy one. too cracked.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
