### PR TITLE
Makes gas masks restrict vision slightly

### DIFF
--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -370,12 +370,13 @@
 	slot_flags = ITEM_SLOT_MASK
 	flags_inv = HIDEFACE|HIDESNOUT|HIDEEARS|HIDEHAIR|HIDEFACIALHAIR
 	sewrepair = TRUE
+	block2add = FOV_BEHIND //should make vision 180 when worn
 	equip_sound = 'sound/items/gasmask/gasmask_on.ogg'
 	var/worn = FALSE
 
 /obj/item/clothing/mask/rogue/gasmask/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
-	if(user.wear_mask == src)
+	if(user.wear_mask == src)//We should probably rework this to account for people who already have the trait
 		ADD_TRAIT(user, TRAIT_NOSTINK, TRAIT_GENERIC)
 		worn = TRUE
 


### PR DESCRIPTION
## About The Pull Request
Makes gas masks restrict visions to 180 degrees. Identical to the vision restriction from Perserdun sallets. 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I tested it in-game, didn't break. Worked well with multiple sources of the vision restriction.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Should make gas masks more of a trade-off; sure, you get immunity to gas attacks, but you're limiting your area perception a little bit. This also encourages taking them off in non-combat zones, and is technically a _slight_ Perserdun buff since Perserdun's sallets restricted their vision by the same amount anyways.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
