### PR TITLE
Bringing persurdunian melee skills in line with risvon

### DIFF
--- a/code/modules/jobs/job_types/roguetown/perserdunian/ammosquire.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/ammosquire.dm
@@ -58,7 +58,7 @@
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/perserdunian/armsman.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/armsman.dm
@@ -60,7 +60,7 @@
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/perserdunian/envoy.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/envoy.dm
@@ -54,7 +54,7 @@
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/perserdunian/knightcommander.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/knightcommander.dm
@@ -62,7 +62,7 @@
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/perserdunian/partisan.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/partisan.dm
@@ -53,7 +53,7 @@
 	H.adjust_skillrank(/datum/skill/craft/blacksmithing, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/smelting, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/perserdunian/rook.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/rook.dm
@@ -60,7 +60,7 @@
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)


### PR DESCRIPTION
## About The Pull Request

Risvonite classes mostly (if not all I didn't check) have journeyman axes, while most Persurdunian classes have apprentice swords. This seems like an oversight so I fixed it. If it's not an oversight then obv y'know don't merge this.

Armsman
Swords 2 -> Swords 3
Soldato has axes 3

Partisan
Swords 2 -> Swords 3
Camp Follower also has swords 3 which should maybe be changed to axes 3 but idk i just work here

Rook
Swords 2 -> Swords 3
Pafanto has axes 3

Ammo Squire
Swords 2 -> Swords 3
Mulo has axes 3

Envoy
Swords 2 -> Swords 3
Consulo also has swords 3

Knight Commander
Swords 2 -> Swords 4
Veterano has Axes 4

## Testing Evidence

Everything compiled fine and given all I did was change 2 -> 3/4(for knight commander) I doubt it would fuck things up

<img width="461" height="80" alt="image" src="https://github.com/user-attachments/assets/d67ce201-6656-4965-835b-b9f050a9512d" />

## Why It's Good For The Game

By my understanding the below classes are meant to be roughly equivalent to eachother, so I sought to ensure that was the case. 
While there are a few other persurdunian classes i think need adjusting to be inline I didn't touch them given this PR is just supposed to be about the melee skills and the lines get a little muddied in comparing curasisto to auxiliarist and chirurgeon
(Notable, Curasisto has pistols 3 and swords 3 while chirurgeon has neither, but given chirurgeon also has a bevy of goons [auxiliarists] idk if I should touch that)
