### PR TITLE
Armsmen, camp follower, partisan gain weaponsmithing in line with soldato

### DIFF
--- a/code/modules/jobs/job_types/roguetown/perserdunian/armsman.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/armsman.dm
@@ -68,6 +68,7 @@
 	H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/rifles, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/armorsmithing, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/weaponsmithing, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/sewing, 3, TRUE)
 	H.change_stat("strength", 1)
 	H.change_stat("constitution", 1)

--- a/code/modules/jobs/job_types/roguetown/perserdunian/partisan.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/partisan.dm
@@ -50,6 +50,7 @@
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/armorsmithing, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/weaponsmithing, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/blacksmithing, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/smelting, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/risvonian/campfollower.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/campfollower.dm
@@ -50,6 +50,7 @@
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/armorsmithing, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/weaponsmithing, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/blacksmithing, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/smelting, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)


### PR DESCRIPTION
## About The Pull Request

Noticed soldato's got weaponsmithing 3 but camp followers didn't get any, then checked their persur counterparts and realized neither got it and it was probably an oversight.

Camp Follower
Weaponsmithing 4 Added (In line with their armorsmithing and blacksmithing skills)

Partisan
Weaponsmithing 4 Added (In line with Camp Follower)

Armsman
Weaponsmithing 3 Added (In line with Soldato)

## Testing Evidence

Just skill additions, should all be good.

<img width="452" height="77" alt="image" src="https://github.com/user-attachments/assets/996416a7-88c7-4401-b360-ba1c0964ee6b" />

## Why It's Good For The Game

These guys are meant to be equal, and Camp Follower/Partisan is supposed to be able to repair things for the Soldato/Armsman

