### PR TITLE
Gives Perserdun medical roles a surgical bag on spawn

### DIFF
--- a/code/modules/jobs/job_types/roguetown/perserdunian/auxiliar.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/auxiliar.dm
@@ -59,6 +59,7 @@
 		/obj/item/natural/cloth,
 		/obj/item/rogueweapon/sword/iron/short,
 		/obj/item/rope,
+		/obj/item/storage/belt/rogue/surgery_bag,
 	)
 	H.adjust_skillrank(/datum/skill/misc/medicine, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/perserdunian/chirurgeon.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/chirurgeon.dm
@@ -53,6 +53,7 @@
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch/pillbottle,
 		/obj/item/storage/belt/rogue/pouch/coins/rich,
+		/obj/item/storage/belt/rogue/surgery_bag,
 		)
 	H.adjust_skillrank(/datum/skill/misc/medicine, 5, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)


### PR DESCRIPTION
## About The Pull Request
Chirurgeon and Auxiliarist get a surgical bag on spawn.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Worked.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Lets Perserdun keep up with Risvon's ability to heal their people. Auxiliarist doesn't really compare to Magiisto; which wouldn't be so bad if there were other medical roles on Perserdun. With Auxiliarist being more numerous, this should balance it out.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
