### PR TITLE
Removes gravemarkers returning someone to the lobby forcefully

### DIFF
--- a/code/modules/roguetown/roguejobs/gravedigger/gravemarker.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/gravemarker.dm
@@ -76,8 +76,8 @@
 
 /obj/structure/gravemarker/OnCrafted(dir, mob/user)
 	icon_state = "gravemarker[rand(1,3)]"
-	for(var/obj/structure/closet/dirthole/hole in loc)
+	/*for(var/obj/structure/closet/dirthole/hole in loc)
 		if(pacify_coffin(hole, user))
 			to_chat(user, span_notice("I feel their soul finding peace..."))
-			SEND_SIGNAL(user, COMSIG_GRAVE_CONSECRATED, hole)
+			SEND_SIGNAL(user, COMSIG_GRAVE_CONSECRATED, hole)*/ //We don't want people being sent back to lobby by being speed buried lol
 	return ..()


### PR DESCRIPTION
## About The Pull Request
Crafting a gravemarker on a grave no longer forcibly returns the corpse's player to the lobby.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiled, no idea if it actually works. Probably does!
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
People were reportedly burying corpses as fast as possible to round remove players. That's... not very fun, I think! So it's gone.

Also, unrelated, but since nobody's ever gonna read this, I can probably mention the fact the reason I was so familiar with Azure Peak's burial code was a kink thing. Buried alive stuff, it was freaky. Fun, though. Would do again.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
