### PR TITLE
[TESTMERGE ONLY] Removes Longstrider from nearly every role

### DIFF
--- a/code/modules/jobs/job_types/roguetown/risvonian/campfollower.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/campfollower.dm
@@ -65,4 +65,3 @@
 	H.change_stat("endurance", 2)
 	H.change_stat("perception", 2)
 	H.change_stat("speed", 2)
-	ADD_TRAIT(H, TRAIT_LONGSTRIDER, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/risvonian/commandant.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/commandant.dm
@@ -81,7 +81,6 @@
 	H.change_stat("perception", 2)
 	H.change_stat("speed", 2)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_LONGSTRIDER, TRAIT_GENERIC)
 
 
 GLOBAL_VAR_INIT(commandant_raid_cooldown, -50000) // Inits variable for later

--- a/code/modules/jobs/job_types/roguetown/risvonian/consulo.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/consulo.dm
@@ -62,4 +62,3 @@
 	H.change_stat("endurance", 2)
 	H.change_stat("perception", 2)
 	H.change_stat("intelligence", 2)
-	ADD_TRAIT(H, TRAIT_LONGSTRIDER, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/risvonian/curacisto.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/curacisto.dm
@@ -72,4 +72,3 @@
 	H.change_stat("endurance", 2)
 	H.change_stat("perception", 2)
 	H.change_stat("speed", 2)
-	ADD_TRAIT(H, TRAIT_LONGSTRIDER, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/risvonian/mulo.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/mulo.dm
@@ -77,4 +77,3 @@
 	H.change_stat("perception", 2)
 	H.change_stat("speed", 2)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_LONGSTRIDER, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/risvonian/oficiro.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/oficiro.dm
@@ -80,4 +80,3 @@
 	H.change_stat("perception", 2)
 	H.change_stat("speed", 2)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_LONGSTRIDER, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/risvonian/pafanto.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/pafanto.dm
@@ -78,4 +78,3 @@
 	H.change_stat("endurance", 1)
 	H.change_stat("perception", 3)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_LONGSTRIDER, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/risvonian/servisto.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/servisto.dm
@@ -78,5 +78,4 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/haste)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/stoneskin)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_LONGSTRIDER, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_ARCYNE_T3, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/risvonian/soldato.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/soldato.dm
@@ -79,4 +79,3 @@
 	H.change_stat("perception", 2)
 	H.change_stat("speed", 2)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_LONGSTRIDER, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/risvonian/veterano.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/veterano.dm
@@ -78,4 +78,3 @@
 	H.change_stat("perception", 2)
 	H.change_stat("speed", 2)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_LONGSTRIDER, TRAIT_GENERIC)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -662,8 +662,7 @@
 
 	else //not currently sneaking, check if we can sneak
 		if(light_amount < rogue_sneaking_light_threshhold + (get_skill_level(/datum/skill/misc/sneaking)/200) && m_intent == MOVE_INTENT_SNEAK)
-			if(skill_level >= SKILL_LEVEL_MASTER)
-				animate(src, alpha = 0, time = used_time)
+			animate(src, alpha = 0, time = used_time)
 			spawn(used_time + 5) regenerate_icons()
 			rogue_sneaking = TRUE
 	return

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -664,7 +664,6 @@
 		if(light_amount < rogue_sneaking_light_threshhold + (get_skill_level(/datum/skill/misc/sneaking)/200) && m_intent == MOVE_INTENT_SNEAK)
 			if(skill_level >= SKILL_LEVEL_MASTER)
 				animate(src, alpha = 0, time = used_time)
-			animate(src, alpha = 0, time = used_time)
 			spawn(used_time + 5) regenerate_icons()
 			rogue_sneaking = TRUE
 	return

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -662,6 +662,8 @@
 
 	else //not currently sneaking, check if we can sneak
 		if(light_amount < rogue_sneaking_light_threshhold + (get_skill_level(/datum/skill/misc/sneaking)/200) && m_intent == MOVE_INTENT_SNEAK)
+			if(skill_level >= SKILL_LEVEL_MASTER)
+				animate(src, alpha = 0, time = used_time)
 			animate(src, alpha = 0, time = used_time)
 			spawn(used_time + 5) regenerate_icons()
 			rogue_sneaking = TRUE


### PR DESCRIPTION
## About The Pull Request
Removes Longstrider from everyone except Bastiono, Kaspafisto, Grand Knight, and the shock kits. Voltigeur will keep it too when added.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It compiled. Did not do any other testing.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Hotly debated subject in the discord; is Longstrider why Risvon beats Perserdun so much?

Well, let's find out. We'll leave this test merged for today, maybe leave it on for the start of next host, too. I do worry that this is taking the wilderness skirmishing out of Risvon, which is a core part of their mechanical identity; but hopefully we can tell soon if this is a good or a bad thing.

Bastiono's keeping it because otherwise Perserdun would have more Longstriders, and Veteranos are supposed to lead their teams rather than rush hard. Perserdun still will have more Longstriders by one with Voltigeur in. I'm open to debate on this, though.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
