### PR TITLE
Soldato helm no longer enbaldens you inconsistently

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
@@ -110,6 +110,10 @@
 	name = "iron kettle helmet"
 	desc = "A kettle helmet made of iron. It protects the top and sides of the head."
 	adjustable = CAN_CADJUST
+	flags_inv = HIDEFACE|HIDESNOUT|HIDEHAIR
+	flags_cover = HEADCOVERSEYES
+	body_parts_covered = HEAD|EARS|HAIR|NOSE|EYES
+	block2add = FOV_BEHIND
 	icon_state = "ikettle_visor"
 	smeltresult = /obj/item/ingot/iron
 	max_integrity = ARMOR_INT_HELMET_IRON


### PR DESCRIPTION
## About The Pull Request

Makes Soldato helm cover hair when the visor is down, and let it flow when the visor is open
Soldato helm visor now actually covers your eyes and nose. It also restricts your vision however.

## Testing Evidence

<img width="116" height="132" alt="image" src="https://github.com/user-attachments/assets/e3e122d0-2fc8-4e20-8693-34e43a9c7151" />

## Why It's Good For The Game

Same principle as the Sallet helm. 