### PR TITLE
Add Faction Dye Stations To Map

### DIFF
--- a/_maps/map_files/temperance/perserdun.dmm
+++ b/_maps/map_files/temperance/perserdun.dmm
@@ -2416,6 +2416,10 @@
 "Js" = (
 /turf/closed/wall/mineral/rogue/perserdun/outercorner/dir8,
 /area/rogue/indoors/perserdunbase)
+"Ju" = (
+/obj/machinery/gear_painter_nocolorwheel/persurdun,
+/turf/open/floor/rogue/perdun,
+/area/rogue/indoors/perserdunbase)
 "JE" = (
 /obj/structure/mineral_door/wood/wardoor,
 /turf/open/floor/rogue/warquad,
@@ -32599,7 +32603,7 @@ Rq
 yW
 CQ
 CQ
-CQ
+Ju
 Qd
 CQ
 wg
@@ -33379,7 +33383,7 @@ Ql
 dc
 CQ
 CQ
-CQ
+Ju
 Qd
 eu
 CQ

--- a/_maps/map_files/temperance/risvon.dmm
+++ b/_maps/map_files/temperance/risvon.dmm
@@ -4267,6 +4267,14 @@
 	},
 /turf/open/floor/rogue/warmetal,
 /area/rogue/under/cave/warmachine)
+"IB" = (
+/obj/structure/fluff/railing/sandbag{
+	dir = 1;
+	pixel_y = 11
+	},
+/obj/machinery/gear_painter_nocolorwheel/risvon,
+/turf/open/floor/rogue/risvon,
+/area/rogue/indoors/risvonbase)
 "IE" = (
 /obj/structure/mineral_door/wood{
 	lockid = "risvontag"
@@ -11408,7 +11416,7 @@ rc
 rc
 rc
 Tx
-xC
+IB
 VR
 rH
 NG
@@ -12838,7 +12846,7 @@ rc
 rc
 My
 Tx
-xC
+IB
 ej
 HT
 ej


### PR DESCRIPTION
## About The Pull Request

Maps in the factional dye stations to the strategy room of each respective faction.

## Testing Evidence

Risvon
<img width="860" height="892" alt="image" src="https://github.com/user-attachments/assets/70f12436-6e58-40a8-a88f-7b0254f644a5" />

Persurdun
<img width="1330" height="669" alt="image" src="https://github.com/user-attachments/assets/d0cc1427-609f-45cf-b134-e2d47eb1aabf" />

## Why It's Good For The Game

Same reasons the PR inventing these dye stations said. Lets people use loadout items while still maintaining coherency with the faction colors, and preventing aggressively neon items
