### PR TITLE
Risvon Helm Backend Cleaning

### DIFF
--- a/_maps/map_files/temperance/perserdun.dmm
+++ b/_maps/map_files/temperance/perserdun.dmm
@@ -2316,7 +2316,7 @@
 /turf/open/floor/rogue/perdun,
 /area/rogue/indoors/perserdunbase)
 "HD" = (
-/obj/item/clothing/head/roguetown/helmet/kettle/iron,
+/obj/item/clothing/head/roguetown/helmet/kettle/iron/soldato,
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/perserdun)
 "HF" = (

--- a/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
@@ -109,17 +109,9 @@
 /obj/item/clothing/head/roguetown/helmet/kettle/iron
 	name = "iron kettle helmet"
 	desc = "A kettle helmet made of iron. It protects the top and sides of the head."
-	adjustable = CAN_CADJUST
-	flags_inv = HIDEFACE|HIDESNOUT|HIDEHAIR
-	flags_cover = HEADCOVERSEYES
-	body_parts_covered = HEAD|EARS|HAIR|NOSE|EYES
-	block2add = FOV_BEHIND
 	icon_state = "ikettle_visor"
 	smeltresult = /obj/item/ingot/iron
 	max_integrity = ARMOR_INT_HELMET_IRON
-
-/obj/item/clothing/head/roguetown/helmet/kettle/iron/ComponentInitialize()
-	AddComponent(/datum/component/adjustable_clothing, (HEAD|EARS|HAIR), HIDEHAIR, null, 'sound/items/visor.ogg', null, UPD_HEAD)
 
 /obj/item/clothing/head/roguetown/helmet/kettle/wide
 	name = "wide kettle helmet"

--- a/code/modules/clothing/rogueclothes/headwear/helmet/t13helmets.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/t13helmets.dm
@@ -37,9 +37,28 @@
 
 
 // medium helmets
+/obj/item/clothing/head/roguetown/helmet/kettle/iron/soldato
+	name = "iron kettle helmet"
+	desc = "A kettle helmet made of iron. It protects the top and sides of the head."
+	adjustable = CAN_CADJUST
+	flags_inv = HIDEFACE|HIDESNOUT|HIDEHAIR
+	flags_cover = HEADCOVERSEYES
+	body_parts_covered = HEAD|EARS|HAIR|NOSE|EYES
+	block2add = FOV_BEHIND
+	icon_state = "ikettle_visor"
+	smeltresult = /obj/item/ingot/iron
+	max_integrity = ARMOR_INT_HELMET_IRON
+
+/obj/item/clothing/head/roguetown/helmet/kettle/iron/soldato/ComponentInitialize()
+	AddComponent(/datum/component/adjustable_clothing, (HEAD|EARS|HAIR), HIDEHAIR, null, 'sound/items/visor.ogg', null, UPD_HEAD)
+
 /obj/item/clothing/head/roguetown/helmet/kettle/iron/visored
 	name = "decorated kettle helmet"
 	desc = "A kettle helmet. It has the visor of a stolen Knight Commander's helmet welded onto it."
+	flags_inv = HIDEFACE|HIDESNOUT|HIDEHAIR
+	flags_cover = HEADCOVERSEYES
+	body_parts_covered = HEAD|EARS|HAIR|NOSE|EYES
+	block2add = FOV_BEHIND
 	icon_state = "ikettlevisor"
 	item_state = "ikettlevisor"
 

--- a/code/modules/jobs/job_types/roguetown/risvonian/soldato.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/soldato.dm
@@ -12,7 +12,7 @@
 	tutorial = "You are the backbone of the Risvon Dictate. You are typically a volunteer, or a conscript. \
 				Your main purpose is follow the orders of your superiors. They are your Oficiros, and your Commandant. \
 				For most of your life, you've been filled with a firm belief that the strong must rule. \
-				You are also a firm believer of the denial of one's desires, in favor for unity and a greater good." 
+				You are also a firm believer of the denial of one's desires, in favor for unity and a greater good."
 
 	outfit = /datum/outfit/job/roguetown/soldato
 	display_order = JDO_SOLDATO
@@ -43,7 +43,7 @@
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron/ziggurate
 	cloak = /obj/item/clothing/cloak/templar/malumite
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
-	head = /obj/item/clothing/head/roguetown/helmet/kettle/iron
+	head = /obj/item/clothing/head/roguetown/helmet/kettle/iron/soldato
 	mask = /obj/item/clothing/mask/rogue/gasmask/risvonmask
 	belt = /obj/item/storage/belt/rogue/leather/black/soldier
 	beltl = /obj/item/flashlight/flare/torch/lantern


### PR DESCRIPTION
## About The Pull Request

All Risvon helms were children of the Soldato helm meaning that helmets that really shouldn't be adjustable were able to be rightclicked making them invisible so on so forth. This makes the soldato helm into it's own helmet type so that it can be made adjustable rather than all helms yada yada

Notably, this makes the commanders helm no longer cover the face and eyes and such, but going off the sprite, that should have always been the case.

## Testing Evidence

video too big but it's in the discord
https://discordapp.com/channels/1427032556825608267/1481438002143170661/1496273640549781647
<img width="456" height="85" alt="image" src="https://github.com/user-attachments/assets/f09666b7-31ba-48e8-8595-3f49070a7af8" />


## Why It's Good For The Game

Cleans up the code, makes helmets that shouldn't be toggleable no longer toggleable. Bugs bad, so on so forth
