### PR TITLE
Sorry folks, the Cock and Ball Torture ends tonight (Smithing Zone Remap)

### DIFF
--- a/_maps/map_files/temperance/perserdun.dmm
+++ b/_maps/map_files/temperance/perserdun.dmm
@@ -1283,6 +1283,11 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/warmetal,
 /area/rogue/under/cave/warmachine)
+"sv" = (
+/obj/effect/decal/cleanable/dirt/grime/dust,
+/obj/machinery/light/rogue/smelter/hiron,
+/turf/open/floor/rogue/perdun,
+/area/rogue/indoors/perserdunbase)
 "sy" = (
 /obj/structure/chair/wood/rogue/fancychair2,
 /obj/structure/fluff/walldeco/terdun{
@@ -1327,6 +1332,18 @@
 /area/rogue/indoors/perserdunbase)
 "sV" = (
 /turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/perserdunbase)
+"tg" = (
+/obj/structure/table/wood/perserdunsmall,
+/obj/item/rogueweapon/hammer/iron{
+	pixel_y = 9
+	},
+/obj/item/rogueweapon/tongs/stone{
+	name = "tongs";
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/rogue/perdun,
 /area/rogue/indoors/perserdunbase)
 "tk" = (
 /obj/structure/mineral_door/bars{
@@ -1475,6 +1492,10 @@
 /area/rogue/indoors/perserdunbase)
 "vf" = (
 /obj/structure/bars,
+/turf/open/floor/rogue/perdun,
+/area/rogue/indoors/perserdunbase)
+"vh" = (
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/perdun,
 /area/rogue/indoors/perserdunbase)
 "vj" = (
@@ -17114,8 +17135,8 @@ Bb
 Bb
 Bb
 Bb
-Bb
 rZ
+Bb
 ow
 hV
 pK
@@ -17244,9 +17265,9 @@ IG
 IG
 IG
 IG
-IG
 Qd
-Km
+tg
+CQ
 CQ
 CQ
 CQ
@@ -17374,12 +17395,12 @@ IG
 IG
 IG
 IG
-IG
 Qd
-au
-CQ
+vh
 Gx
-Yz
+OV
+CQ
+sv
 Qd
 Zc
 ng
@@ -17504,9 +17525,9 @@ IG
 IG
 IG
 IG
-IG
 Qd
 Ik
+CQ
 CQ
 CQ
 CQ
@@ -17634,12 +17655,12 @@ IG
 IG
 IG
 IG
-IG
 Qd
-au
-nw
+vh
 Gx
-OV
+Yz
+CQ
+au
 Bw
 nT
 hc
@@ -17764,9 +17785,9 @@ IG
 IG
 IG
 IG
-IG
-lC
+Qd
 Ik
+CQ
 CQ
 CQ
 nw
@@ -17894,12 +17915,12 @@ IG
 IG
 IG
 IG
-IG
 Qd
-au
-nw
+vh
 Gx
-OV
+Yz
+CQ
+au
 rT
 ow
 Bb
@@ -18024,9 +18045,9 @@ IG
 IG
 IG
 IG
-IG
 Qd
 Km
+CQ
 CQ
 CQ
 CQ
@@ -18154,9 +18175,9 @@ IG
 IG
 IG
 IG
-IG
 rT
 nT
+Km
 Km
 Km
 Rm
@@ -18285,8 +18306,8 @@ IG
 IG
 IG
 IG
-IG
 rT
+Bb
 Bb
 Bb
 Js

--- a/_maps/map_files/temperance/risvon.dmm
+++ b/_maps/map_files/temperance/risvon.dmm
@@ -22,6 +22,10 @@
 	},
 /turf/open/floor/rogue/risvon,
 /area/rogue/indoors/risvonbasebar)
+"as" = (
+/obj/machinery/light/rogue/smelter/hiron,
+/turf/open/floor/rogue/risvon,
+/area/rogue/indoors/risvonbase)
 "at" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -2963,23 +2967,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/risvonbase)
 "yx" = (
-/obj/structure/fluff/railing/border/west{
-	pixel_x = -7
-	},
-/obj/structure/fluff/railing/border/east{
-	pixel_x = 4;
-	pixel_y = 2;
-	layer = 4.11
-	},
-/obj/structure/fluff/railing/border/east{
-	pixel_x = 4;
-	pixel_y = -4;
-	layer = 4.11
-	},
 /obj/structure/fluff/walldeco/happy{
 	pixel_y = 31
 	},
-/turf/open/floor/rogue/risvon,
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/risvonbase)
 "yB" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
@@ -3818,7 +3810,7 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/risvonbase)
 "EB" = (
-/obj/machinery/light/rogue/smelter/hiron,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/risvonbase)
 "EH" = (
@@ -13365,8 +13357,8 @@ uF
 Jv
 Tx
 yx
-xK
-xK
+Qw
+as
 xK
 Tx
 wu
@@ -13494,9 +13486,9 @@ xK
 xK
 lO
 Tx
-EB
+XO
 Qw
-eY
+xK
 FW
 Tx
 wu
@@ -13624,9 +13616,9 @@ iw
 KM
 XY
 Tx
-XO
+EB
 Qw
-xK
+eY
 xK
 Tx
 wu


### PR DESCRIPTION
## About The Pull Request

Shuffles the smithing areas of each faction around to make them not suck dick and balls to use.

## Testing Evidence


https://github.com/user-attachments/assets/108b02d6-a8b3-48aa-9a5f-46f28f78a30d



## Why It's Good For The Game

Current smithing setups have no waterbins to douse (complete) forging with, moving the bloomery also prevents ye dreaded circumstance where you misclick next to the anvil and onto the bloomery and watch as the armor you were trying to repair is rendered into its base components
