### PR TITLE
Prevents Roundstart Antags spawning in SPITE OF THE VENERABLE-MASTER RAB

### DIFF
--- a/code/datums/storytellers/gods.dm
+++ b/code/datums/storytellers/gods.dm
@@ -19,6 +19,10 @@
 	always_votable = TRUE
 	color_theme = "#80ced8"
 
+	//Sets probability of roundstart antag to 0. One would think no character injection would be good enough, but here we are. This is also on other codebases psydon so prob the way to fix it.
+	guarantees_roundstart_roleset = FALSE
+	roundstart_prob = 0 //Sets probability of roundstart antag to 0. One would think no character injection would be good enough, but here we are. This is also on other codebases psydon so prob the way to fix it.
+
 	//Has no influence, your actions will not impact him his spawn rates. Cus he's asleep.
 	//Tl;dr - higher event spawn rates to keep stuff interesting, no god intervention, no antags. (Raids and omens will still happen at normal rate.)
 	point_gains_multipliers = list(


### PR DESCRIPTION
## About The Pull Request

Adds some stuff to the standard storyteller to make sure antags dont spawn roundstart circumventing the other stuff that was meant to stop them from spawning

## Testing Evidence

I don't have a good way to test this ingame as it was an inconsistent thing whether it happened or not, but it compiles fine and from what I can see on other rogue codebases with storytellers they also have this so 🤷 

<img width="461" height="99" alt="image" src="https://github.com/user-attachments/assets/db11041e-9ecd-4501-9b08-27e22d896059" />

## Why It's Good For The Game

Antags shouldn't be spawning. This makes them not spawn.