### PR TITLE
Robes Cloak Slot Sleeves Fix

### DIFF
--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -14,6 +14,19 @@
 	l_sleeve_status = SLEEVE_NORMAL
 	experimental_inhand = FALSE
 
+/obj/item/clothing/suit/roguetown/shirt/robe/equipped(mob/user, slot, initial = FALSE)
+    . = ..()
+    if(slot == SLOT_CLOAK)
+        src.sleeved = null
+    else
+        src.sleeved = initial(src.sleeved) // restore original value
+    update_icon()
+
+/obj/item/clothing/suit/roguetown/shirt/robe/dropped(mob/user)
+    . = ..()
+    src.sleeved = initial(src.sleeved)
+    update_icon()
+
 /obj/item/clothing/suit/roguetown/shirt/robe/astrata
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT|ITEM_SLOT_CLOAK
 	name = "sun robe"

--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -19,7 +19,7 @@
     if(slot == SLOT_CLOAK)
         src.sleeved = null
     else
-        src.sleeved = initial(src.sleeved) // restore original value
+        src.sleeved = initial(src.sleeved) // just in case it bugs out somehow
     update_icon()
 
 /obj/item/clothing/suit/roguetown/shirt/robe/dropped(mob/user)


### PR DESCRIPTION
## About The Pull Request

robes could originally be placed in the cloak slot, but having sleeves on them broke it for some reason. this makes it so when robes are put in the cloak slot, the sleeves are temporarily set to null in order for the icon to work properly. this probably messes with other shit and is a bandaid fix but hey it works

## Testing Evidence

noooo runtimes ser code works good ser i promise ser 

## Why It's Good For The Game

you are no longer SHIRTLESS and WEIRD if you put your robes in your cloak slot
