### PR TITLE
Blood Needle change

### DIFF
--- a/code/modules/spells/spell_types/wizard/misc/blood_needle.dm
+++ b/code/modules/spells/spell_types/wizard/misc/blood_needle.dm
@@ -34,15 +34,14 @@
 	if(!proximity)
 		return
 	user.say(catchphrase, forced = "spell")
-	playsound(get_turf(user), on_use_sound,50,TRUE)
 	charges--
 	if(charges <= 0)
 		qdel(src)
 
 /obj/item/needle/touch_attack/Destroy()
 	if(attached_spell)
+		playsound(get_turf(src), on_use_sound,50,TRUE)
 		attached_spell.on_hand_destroy(src)
-		playsound(get_turf(attached_spell), on_use_sound,50,TRUE)
 	return ..()
 
 

--- a/code/modules/spells/spell_types/wizard/misc/blood_needle.dm
+++ b/code/modules/spells/spell_types/wizard/misc/blood_needle.dm
@@ -42,6 +42,7 @@
 /obj/item/needle/touch_attack/Destroy()
 	if(attached_spell)
 		attached_spell.on_hand_destroy(src)
+		playsound(get_turf(attached_spell), on_use_sound,50,TRUE)
 	return ..()
 
 


### PR DESCRIPTION
## About The Pull Request

makes it so instead of playing blood_needle_use everytime a charge is used, it only plays when the thing is destroyed. this means that it still plays when it poofs, however it will also play if you click the spell again to get rid of it early (it didn't do that before)

## Testing Evidence

Son. (it works)

## Why It's Good For The Game

flows better methinks and makes my autism happy happy happy yay
