### PR TITLE
[TESTMERGE] No more antags for real I pinky promise free download no virus

### DIFF
--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -6,6 +6,22 @@
 ///the duration into the round for which roundstart events are still valid to run
 #define ROUNDSTART_VALID_TIMEFRAME 3 MINUTES
 
+/proc/is_storyteller_pending_or_roundstart(storyteller_type)
+	if(!ispath(storyteller_type, /datum/storyteller))
+		return FALSE
+	if(SSticker && SSticker.current_state != GAME_STATE_PLAYING && SSticker.current_state != GAME_STATE_FINISHED)
+		return SSgamemode.selected_storyteller == storyteller_type
+	if(ispath(SSgamemode.roundstart_storyteller, /datum/storyteller))
+		return SSgamemode.roundstart_storyteller == storyteller_type
+	return istype(SSgamemode.current_storyteller, storyteller_type)
+
+
+/proc/is_storyteller_villain_blocked()
+	return is_storyteller_pending_or_roundstart(/datum/storyteller/eora) || is_storyteller_pending_or_roundstart(/datum/storyteller/psydon)
+
+/proc/is_roundstart_roles_blocked_storyteller()
+	return is_storyteller_villain_blocked()
+
 SUBSYSTEM_DEF(gamemode)
 	name = "Gamemode"
 	init_order = INIT_ORDER_GAMEMODE
@@ -23,9 +39,13 @@ SUBSYSTEM_DEF(gamemode)
 	/// Our storyteller. They progresses our trackboards and picks out events
 	var/datum/storyteller/current_storyteller
 	/// Result of the storyteller vote/pick. Defaults to Astrata.
-	var/selected_storyteller = /datum/storyteller/psydon
+	var/selected_storyteller = /datum/storyteller/standard
+	/// Storyteller that won the roundstart vote/pick for this round. Remains fixed after the round begins.
+	var/roundstart_storyteller
 	/// List of all the storytellers. Populated at init. Associative from type
 	var/list/storytellers = list()
+	/// Cached storyteller type that won the previous round's storyteller vote.
+	var/last_storyteller_vote
 	/// Next process for our storyteller. The wait time is STORYTELLER_WAIT_TIME
 	var/next_storyteller_process = 0
 	/// Associative list of even track points.
@@ -415,9 +435,11 @@ SUBSYSTEM_DEF(gamemode)
 		calc_value *= current_storyteller?.starting_point_multipliers[track]
 		calc_value *= (rand(100 - current_storyteller?.roundstart_points_variance,100 + current_storyteller?.roundstart_points_variance)/100)
 		event_track_points[track] = min(round(calc_value), round(point_thresholds[track] * 1.25))
+		if(track == EVENT_TRACK_CHARACTER_INJECTION && is_roundstart_roles_blocked_storyteller())
+			event_track_points[track] = 0
 
 	/// If the storyteller guarantees an antagonist roll, add points to make it so.
-	if(current_storyteller?.guarantees_roundstart_roleset && event_track_points[EVENT_TRACK_CHARACTER_INJECTION] < point_thresholds[EVENT_TRACK_CHARACTER_INJECTION])
+	if(!is_roundstart_roles_blocked_storyteller() && current_storyteller?.guarantees_roundstart_roleset && event_track_points[EVENT_TRACK_CHARACTER_INJECTION] < point_thresholds[EVENT_TRACK_CHARACTER_INJECTION])
 		event_track_points[EVENT_TRACK_CHARACTER_INJECTION] = point_thresholds[EVENT_TRACK_CHARACTER_INJECTION]
 
 	/// If we have any forced events, ensure we get enough points for them
@@ -521,6 +543,13 @@ SUBSYSTEM_DEF(gamemode)
 		for(var/type in subtypesof(/datum/storyteller))
 			storytellers[type] = new type()
 	set_storyteller(/datum/storyteller/astrata)
+	calculate_ready_players()
+	roll_pre_setup_points()
+
+	if(!current_storyteller || current_storyteller.type != selected_storyteller)
+		init_storyteller()
+	if(!ispath(roundstart_storyteller, /datum/storyteller))
+		roundstart_storyteller = selected_storyteller
 	calculate_ready_players()
 	roll_pre_setup_points()
 	//handle_pre_setup_roundstart_events()
@@ -1278,7 +1307,7 @@ SUBSYSTEM_DEF(gamemode)
 	var/total_influence = get_follower_influence(chosen_storyteller)
 	for(var/influence_factor in initialized_storyteller.influence_factors)
 		total_influence += calculate_specific_influence(chosen_storyteller, influence_factor)
-	
+
 	total_influence += initialized_storyteller.bonus_points
 
 	return total_influence

--- a/code/datums/storytellers/_base.dm
+++ b/code/datums/storytellers/_base.dm
@@ -83,10 +83,10 @@
 	if(!round_started || disable_distribution) // we are differing roundstarted ones until base roundstart so we can get cooler stuff
 		return
 
-	if(!guarantees_roundstart_roleset && prob(roundstart_prob) && !roundstart_checks)
+	if(!is_roundstart_roles_blocked_storyteller() && !guarantees_roundstart_roleset && prob(roundstart_prob) && !roundstart_checks)
 		roundstart_checks = TRUE
 
-	if(SSgamemode.current_roundstart_event && !SSgamemode.ran_roundstart && (guarantees_roundstart_roleset || roundstart_checks))
+	if(!is_roundstart_roles_blocked_storyteller() && SSgamemode.current_roundstart_event && !SSgamemode.ran_roundstart && (guarantees_roundstart_roleset || roundstart_checks))
 		buy_event(SSgamemode.current_roundstart_event, EVENT_TRACK_CHARACTER_INJECTION, TRUE)
 		if(EVENT_TRACK_CHARACTER_INJECTION in SSgamemode.forced_next_events)
 			SSgamemode.forced_next_events[EVENT_TRACK_CHARACTER_INJECTION] = null

--- a/code/datums/storytellers/temperance.dm
+++ b/code/datums/storytellers/temperance.dm
@@ -1,0 +1,44 @@
+///Snowflake Storytellers
+#define TEMPERANCE_STORYTELLERS list( \
+	/datum/storyteller/standard, \
+	/datum/storyteller/evil, \
+	)
+
+/datum/storyteller/standard
+	name = "STANDARD"
+	desc = "You have been given the right to vote for.. NOTHING! The standard Temperance 13 experience."
+	weight = 6
+	always_votable = TRUE
+	color_theme = "#80ced8"
+
+	//Sets probability of roundstart antag to 0. One would think no character injection would be good enough, but here we are. This is also on other codebases psydon so prob the way to fix it.
+	guarantees_roundstart_roleset = FALSE
+	roundstart_prob = 0 //Sets probability of roundstart antag to 0. One would think no character injection would be good enough, but here we are. This is also on other codebases psydon so prob the way to fix it.
+
+	//Has no influence, your actions will not impactspawn rates.
+	//Tl;dr - higher event spawn rates to keep stuff interesting, no god intervention, no antags. (Raids and omens will still happen at normal rate.)
+	point_gains_multipliers = list(
+		EVENT_TRACK_MUNDANE = 1.2,
+		EVENT_TRACK_MODERATE = 1.2,
+		EVENT_TRACK_INTERVENTION = 0,			//No god intervention, cus he's asleep.
+		EVENT_TRACK_CHARACTER_INJECTION = 0,	//No antagonist spawns.
+	)
+
+/datum/storyteller/evil
+	name = "DANGER"
+	desc = "You have been given the right to vote for.. WAR! Foreign Powers are at play, and the reaper sharpens his scythe in waiting."
+	weight = 6
+	always_votable = FALSE
+	color_theme = "#CC4444"
+
+	point_gains_multipliers = list(
+		EVENT_TRACK_MUNDANE = 1,
+		EVENT_TRACK_PERSONAL = 1.2,
+		EVENT_TRACK_MODERATE = 1.1,
+		EVENT_TRACK_INTERVENTION = 0, //I'm assuming we don't want divine intervention in our grimshittening.
+		EVENT_TRACK_CHARACTER_INJECTION = 1,	//Guarenteed antagonist spawn
+		EVENT_TRACK_OMENS = 1.3,
+		EVENT_TRACK_RAIDS = 0.8,
+	)
+
+	cost_variance = 50  // Events will be highly variable in cost

--- a/code/modules/events/antagonist/solo/bandits.dm
+++ b/code/modules/events/antagonist/solo/bandits.dm
@@ -51,6 +51,11 @@
 	typepath = /datum/round_event/antagonist/solo/bandits
 	antag_datum = /datum/antagonist/bandit
 
+/datum/round_event_control/antagonist/solo/bandits/preRunEvent()
+	if(is_storyteller_villain_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/round_event/antagonist/solo/bandits
 	var/leader = FALSE
 

--- a/code/modules/events/antagonist/solo/lich.dm
+++ b/code/modules/events/antagonist/solo/lich.dm
@@ -55,4 +55,9 @@
 		"Apothecary"
 	)
 
+/datum/round_event_control/antagonist/solo/lich/preRunEvent()
+	if(is_storyteller_villain_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/round_event/antagonist/solo/lich

--- a/code/modules/events/antagonist/solo/rebels.dm
+++ b/code/modules/events/antagonist/solo/rebels.dm
@@ -53,4 +53,9 @@
 		"Apothecary"
 	)
 
+/datum/round_event_control/antagonist/solo/rebel/preRunEvent()
+	if(is_storyteller_villain_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/round_event/antagonist/solo/rebel

--- a/code/modules/events/antagonist/solo/vampires.dm
+++ b/code/modules/events/antagonist/solo/vampires.dm
@@ -55,6 +55,11 @@
 		"Apothecary"
 	)
 
+/datum/round_event_control/antagonist/solo/vampire/preRunEvent()
+	if(is_storyteller_villain_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/round_event/antagonist/solo/vampire
 	var/leader = FALSE
 

--- a/code/modules/events/antagonist/solo/vampires_and_werewolves.dm
+++ b/code/modules/events/antagonist/solo/vampires_and_werewolves.dm
@@ -53,6 +53,11 @@
 		"Apothecary"
 	)
 
+/datum/round_event_control/antagonist/solo/vampires_and_werewolves/preRunEvent()
+	if(is_storyteller_villain_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/round_event/antagonist/solo/vampires_and_werewolves
 	var/leader = FALSE
 

--- a/code/modules/events/antagonist/solo/werewolf.dm
+++ b/code/modules/events/antagonist/solo/werewolf.dm
@@ -54,4 +54,9 @@
 		"Apothecary"
 	)
 
+/datum/round_event_control/antagonist/solo/werewolf/preRunEvent()
+	if(is_storyteller_villain_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/round_event/antagonist/solo/werewolf


### PR DESCRIPTION
## About The Pull Request

Partial port of https://github.com/Azure-Peak/Azure-Peak/pull/6269 taking only the parts which disable antags. Yippee
Also makes a file for Temperance Storytellers so that our storytellers can be our own snowflake ones and quirky and such.

## Testing Evidence

Again, I don't have a way to properly test this as it's not something that you can consistently trigger, but it compiles fine.
<img width="454" height="84" alt="image" src="https://github.com/user-attachments/assets/cbe14748-bb63-480e-a2ca-1ab35319a1d1" />


## Why It's Good For The Game

Bugs bad, and the STANDARD storyteller shouldn't be spawning antags.
