### PR TITLE
tiny marking edits on tiletians and black beasts

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -117,7 +117,7 @@
 		/datum/body_marking/harlequinreversed,
 		/datum/body_marking/bangs,
 		/datum/body_marking/bun,
-	)
+	)	/datum/body_marking/facepaint
 	descriptor_choices = list(
 		/datum/descriptor_choice/height,
 		/datum/descriptor_choice/body,

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -117,7 +117,8 @@
 		/datum/body_marking/harlequinreversed,
 		/datum/body_marking/bangs,
 		/datum/body_marking/bun,
-	)	/datum/body_marking/facepaint
+		/datum/body_marking/facepaint
+	)
 	descriptor_choices = list(
 		/datum/descriptor_choice/height,
 		/datum/descriptor_choice/body,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
@@ -84,8 +84,10 @@
 		/datum/body_marking/flushed_cheeks,
 		/datum/body_marking/eyeliner,
 		/datum/body_marking/tonage,
+		/datum/body_marking/nose,
 		/datum/body_marking/bangs,
 		/datum/body_marking/bun,
+		/datum/body_marking/facepaint
 	)
 	languages = list(
 		/datum/language/common,


### PR DESCRIPTION
## About The Pull Request

Tiletians and black beasts were inexplicably missing the facepaint marking (and also the nose marking on tiletians), this pr fixes this.

## Testing Evidence

<img width="759" height="334" alt="Screenshot 2026-04-24 175424" src="https://github.com/user-attachments/assets/33250dfb-3739-4f70-9de2-6a1511b0ddbf" />

<img width="813" height="318" alt="Screenshot 2026-04-24 175451" src="https://github.com/user-attachments/assets/71d78a17-8e84-432b-8dae-ead7bb48a5d8" />


## Why It's Good For The Game

More variety in customisation is good.
