### PR TITLE
Cock And Ball Torture Ends Tonight (Radio Mortar Spell no longer available to everyone)

### DIFF
--- a/code/modules/spells/spell_types/wizard/invoked_single_target/radiomortar.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_single_target/radiomortar.dm
@@ -15,7 +15,7 @@
 	charging_slowdown = 2
 	chargedloop = /datum/looping_sound/invokeradio
 	associated_skill = /datum/skill/magic/arcane
-	spell_tier = 3
+	spell_tier = 5
 	gesture_required = TRUE
 	range = 7
 	var/delay = 10


### PR DESCRIPTION
## About The Pull Request

Changes the spell tier of the mortar spell to 5. There is no trait which gives the player tier 5 spell tier, meaning it should be impossible for people to get their grubby mitts on unless an admin messes with them in one way or another.

Or they're the radio trooper, which is who the spell was actually meant for in the first place.

## Testing Evidence

Just a number change, shouldn't be anything terrible.

## Why It's Good For The Game

Meant to be a shocktroop ability, not something anyone can get.