### PR TITLE
[TESTMERGE] War Priest Buffs (again)

### DIFF
--- a/code/datums/status_effects/rogue/temperance/tempbuff.dm
+++ b/code/datums/status_effects/rogue/temperance/tempbuff.dm
@@ -10,7 +10,7 @@
 	alert_type = /atom/movable/screen/alert/status_effect/buff/bloodhealing
 	duration = 30 SECONDS
 	examine_text = "SUBJECTPRONOUN is surrounded by strands of blood!"
-	var/healing_on_tick = 1.5
+	var/healing_on_tick = 2
 	var/outline_colour = "#681010"
 
 /datum/status_effect/buff/bloodhealing/on_creation(mob/living/new_owner, new_healing_on_tick)

--- a/code/datums/status_effects/rogue/temperance/tempbuff.dm
+++ b/code/datums/status_effects/rogue/temperance/tempbuff.dm
@@ -10,7 +10,7 @@
 	alert_type = /atom/movable/screen/alert/status_effect/buff/bloodhealing
 	duration = 30 SECONDS
 	examine_text = "SUBJECTPRONOUN is surrounded by strands of blood!"
-	var/healing_on_tick = 1
+	var/healing_on_tick = 1.5
 	var/outline_colour = "#681010"
 
 /datum/status_effect/buff/bloodhealing/on_creation(mob/living/new_owner, new_healing_on_tick)
@@ -30,7 +30,16 @@
 	var/list/wCount = owner.get_wounds()
 	if(!owner.construct)
 		if(wCount.len > 0)
-			owner.heal_wounds(healing_on_tick)
+			owner.heal_wounds(healing_on_tick, list(
+			/datum/wound/artery,
+			/datum/wound/bite,
+			/datum/wound/dismemberment,
+			/datum/wound/facial,
+			/datum/wound/lashing,
+			/datum/wound/puncture,
+			/datum/wound/scarring,
+			/datum/wound/slash,
+			))
 			owner.update_damage_overlays()
 
 /datum/status_effect/buff/bloodhealing/on_remove()

--- a/code/modules/spells/roguetown/rab.dm
+++ b/code/modules/spells/roguetown/rab.dm
@@ -90,7 +90,7 @@
 	invocation_type = "none"
 	associated_skill = /datum/skill/magic/blood
 	antimagic_allowed = FALSE
-	recharge_time = 45 SECONDS
+	recharge_time = 5 SECONDS
 	var/blood_price = 5
 	var/blood_vol_restore = 7.5 //30 every 2 seconds.
 	var/vol_per_skill = 1	//54 with legendary


### PR DESCRIPTION
## About The Pull Request

this doubles the healing per tick on war priest, but as a result, they can't fix fractures or dislocations anymore. also lowers the blood transfer cd because 45 seconds was a lil crazy

might be op who knows, if the healing is too fast i can bump it back down

## Testing Evidence

works ingame, doesn't fix fractures or dislocations as far as i'm aware but i think it still fixes normal bleeds? i'm not sure, i gave myself a fracture and then healed up and tried to sew but it said there weren't any sewable wounds which made me assume it was bleeding because of the fracture lmao

## Why It's Good For The Game

i was told that the healing for wounds was a bit slow at times, and considering the long CD and the fact that WP might have multiple people to try and sew up at once i buffed the miracle so they could pop it on someone and then help sew up someone else whilst the miracle was on cd

if the tick per heal is too strong it's easy to nerf dw

"who is power creeping war priest???"
<img width="498" height="268" alt="image" src="https://github.com/user-attachments/assets/6b2ebcbe-73af-402e-a4ed-87b30189d228" />
