### PR TITLE
Removes duplicate definition from Temperance Storytellers

### DIFF
--- a/code/datums/storytellers/temperance.dm
+++ b/code/datums/storytellers/temperance.dm
@@ -1,5 +1,4 @@
-/// Divine pantheon storytellers
-#define DIVINE_STORYTELLERS list( \
+#define TEMPERANCE_STORYTELLERS list( \
 	/datum/storyteller/standard, \
 	/datum/storyteller/evil, \
 )


### PR DESCRIPTION
## About The Pull Request

Changes the define for temperance storytellers so that it's no longer a duplicate define
Thank you to notactuallytownsends for bringing this to my attention

## Testing Evidence

All still works
<img width="400" height="420" alt="image" src="https://github.com/user-attachments/assets/631b21b3-2860-4f17-a2db-9578eedf4261" />

## Why It's Good For The Game

Bug/Warning bad, Fix good.
