### PR TITLE
Makes it so you can't shoot longarms without a free hand

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -41,6 +41,7 @@
 	var/burst_delay = 2 //amount of deciseconds between each shot if bursting
 	var/pb_knockback = 0
 
+	var/longarm = FALSE//used to determine if you can shoot it one-handed
 
 
 /obj/item/gun/Destroy()
@@ -132,6 +133,11 @@
 	if(!can_shoot()) //Just because you can pull the trigger doesn't mean it can shoot.
 		shoot_with_empty_chamber(user)
 		return
+	if(longarm == TRUE)
+		if(user.get_inactive_held_item() != null)
+			to_chat(user, "<span class='warning'>I can't fire [src] one-handed!</span>")
+			return	
+		
 
 	if(user?.used_intent.arc_check() && target.z != user.z) //temporary fix for openspace arrow dupe
 		target = get_turf(locate(target.x, target.y, user.z))

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -180,6 +180,7 @@
 	experimental_inhand = FALSE
 	slot_flags = ITEM_SLOT_BACK
 	sellprice = 40
+	longarm = TRUE
 
 /obj/item/gun/ballistic/revolver/sawedoff
 	name = "TIZ 'Persuader' Pocket Shotgun"
@@ -199,6 +200,7 @@
 	experimental_inhand = FALSE
 	slot_flags = ITEM_SLOT_HIP
 	sellprice = 20
+	longarm = FALSE //it's a pocket gun with one round, it should be okay
 
 /obj/item/gun/ballistic/revolver/judge
 	name = "TYK 'Judge' Revolving Rifle"
@@ -220,6 +222,7 @@
 	experimental_inhand = FALSE
 	slot_flags = ITEM_SLOT_BACK
 	sellprice = 64
+	longarm = TRUE
 
 /obj/item/gun/ballistic/revolver/mercy
 	name = "LC 'Mercy' Revolver"

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -38,6 +38,7 @@
 	internal_magazine = TRUE 
 	semi_auto = FALSE
 	dry_fire_sound = 'sound/combat/ranged/gun_empty.ogg'
+	longarm = TRUE
 
 /obj/item/gun/ballistic/rifle/process_chamber(mob/living/user, empty_chamber = 0)
 	return ..() //changed argument value

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -36,6 +36,7 @@
 	internal_magazine = TRUE 
 	semi_auto = FALSE
 	dry_fire_sound = 'sound/combat/ranged/gun_empty.ogg'
+	longarm = TRUE
 
 /obj/item/gun/ballistic/shotgun/process_chamber(mob/living/user, empty_chamber = 0)
 	return ..()


### PR DESCRIPTION
## About The Pull Request
You can no longer shoot a long-arm one-handed. Longarm designation is arbitrary, so we can change it per gun.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
worked
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Dual wielding shotguns is stupid
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
