### PR TITLE
Bulworkin' it

### DIFF
--- a/code/modules/jobs/job_types/roguetown/town/bulwark.dm
+++ b/code/modules/jobs/job_types/roguetown/town/bulwark.dm
@@ -104,14 +104,14 @@
 	H.adjust_skillrank(/datum/skill/combat/rifles, 4, TRUE)
 	H.change_stat("perception", 2)
 
-/datum/advclass/bulwark/lmg
+/datum/advclass/bulwark/gunner
 	name = "Gunner"
 	tutorial = "You've selected one of the ONLY machineguns in Kingsrow possession. Armed with a KR 'Leonard,' your territory is all in support. The gun's been modified to take smaller rounds, conserve your ammo, if you can."
-	outfit = /datum/outfit/job/roguetown/bulwark/lmg
+	outfit = /datum/outfit/job/roguetown/bulwark/gunner
 	category_tags = list(CTAG_BULWARK)
 
-/datum/outfit/job/roguetown/bulwark/rifle/pre_equip(mob/living/carbon/human/H)
-	backl = /obj/item/gun/ballistic/rifle/lewis
+/datum/outfit/job/roguetown/bulwark/gunner/pre_equip(mob/living/carbon/human/H)
+	backl = /obj/item/gun/ballistic/rifle/repeater/lewis
 	backr = /obj/item/storage/backpack/rogue/backpack
 	r_hand = /obj/item/storage/belt/rogue/pouch/panbag/lewis
 	backpack_contents = list(
@@ -122,3 +122,4 @@
 		/obj/item/ammo_box/magazine/luger = 3,
 	)
 	H.adjust_skillrank(/datum/skill/combat/rifles, 4, TRUE)
+	H.change_stat("speed", -4)

--- a/code/modules/jobs/job_types/roguetown/town/bulwark.dm
+++ b/code/modules/jobs/job_types/roguetown/town/bulwark.dm
@@ -102,3 +102,23 @@
 		/obj/item/ammo_box/magazine/luger = 3,
 	)
 	H.adjust_skillrank(/datum/skill/combat/rifles, 4, TRUE)
+	H.change_stat("perception", 2)
+
+/datum/advclass/bulwark/lmg
+	name = "Gunner"
+	tutorial = "You've selected one of the ONLY machineguns in Kingsrow possession. Armed with a KR 'Leonard,' your territory is all in support. The gun's been modified to take smaller rounds, conserve your ammo, if you can."
+	outfit = /datum/outfit/job/roguetown/bulwark/lmg
+	category_tags = list(CTAG_BULWARK)
+
+/datum/outfit/job/roguetown/bulwark/rifle/pre_equip(mob/living/carbon/human/H)
+	backl = /obj/item/gun/ballistic/rifle/lewis
+	backr = /obj/item/storage/backpack/rogue/backpack
+	r_hand = /obj/item/storage/belt/rogue/pouch/panbag/lewis
+	backpack_contents = list(
+		/obj/item/reagent_containers/glass/bottle/rogue/healthpotnew = 2,
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 1,
+		/obj/item/storage/keyring/gatemaster = 1,
+		/obj/item/flashlight/flare/torch/lantern = 1,
+		/obj/item/ammo_box/magazine/luger = 3,
+	)
+	H.adjust_skillrank(/datum/skill/combat/rifles, 4, TRUE)


### PR DESCRIPTION
## About The Pull Request

Adds the lewis gun to bulwarks as a gunner kit, has -4 speed by default
Gives +2 perception to the bulwark marksman kit to give it more likeability over the shotgun kit

## Testing Evidence

yes it runs with no errors
https://cdn.discordapp.com/attachments/1427033245098315887/1499645489635790859/TEMPERANCE_13_2026-05-01_01-32-44.mp4?ex=69f58d32&is=69f43bb2&hm=2fe24a6574b9796541254efb853c62cf3a913aff480bc44ac0a6d45d67160b9b&
## Why It's Good For The Game

ever since I atomized the main pr I forgot to add this in, the gun's been sitting around and it's been meant to be for bulwarks since I got it made. 