### PR TITLE
Add lock/unlocking with equipped keys (RMB)

### DIFF
--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -9,8 +9,8 @@
 	w_class = WEIGHT_CLASS_TINY
 	dropshrink = 0.75
 	throwforce = 0
-	var/lockhash = 0
-	var/lockid = null
+	lockhash = 0
+	lockid = null
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_MOUTH|ITEM_SLOT_NECK
 	drop_sound = 'sound/items/gems (1).ogg'
 	anvilrepair = /datum/skill/craft/blacksmithing
@@ -637,7 +637,7 @@
 	icon_state = "brownkey"
 	w_class = WEIGHT_CLASS_TINY
 	dropshrink = 0.75
-	var/lockhash = 0
+	lockhash = 0
 
 /obj/item/customblank/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/rogueweapon/hammer))
@@ -670,7 +670,7 @@
 	icon_state = "lock"
 	w_class = WEIGHT_CLASS_SMALL
 	dropshrink = 0.75
-	var/lockhash = 0
+	lockhash = 0
 
 /obj/item/customlock/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/rogueweapon/hammer))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -58,6 +58,21 @@
 	/// Icon to use as a 32x32 preview in crafting menus and such
 	var/icon_state_preview
 
+	/// For doors, chests, pillories. etc, tracks whether this object has a keyed lock installed.
+	/// Certain vending machines do not use this variable at present.
+	/// If TRUE: Doors, closets, chests will use a random lockhash for (un)locking, generated & accessed based on the object's lockid.
+	var/keylock = FALSE
+	/// The lock ID, used with keys and lockable objects.
+	/// Used for getting the corresponding lockhash.
+	/// If unset but keylock is TRUE, an unconnected lockhash will be generated.
+	/// Type is STRING.
+	var/lockid
+	/// The lockhash corresponding to a key's lockid. Initialized 
+	/// Type is NUMBER.
+	var/lockhash
+	/// Is this object currently locked? TRUE or FALSE.
+	var/locked
+
 	vis_flags = VIS_INHERIT_PLANE
 
 /obj/vv_edit_var(vname, vval)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -12,6 +12,8 @@
 	var/climb_offset = 0 //offset up when climbed
 	var/mob/living/structureclimber
 	var/hammer_repair
+	keylock = FALSE
+	lockhash = 0
 //	move_resist = MOVE_FORCE_STRONG
 
 /obj/structure/Initialize()
@@ -188,3 +190,71 @@
 				return  "It looks pretty damaged."
 			if(1 to 25)
 				return  span_warning("It's about to break.")
+
+
+/// Helper proc to find a matching key or keyring in certain equipment slots on a mob.
+/obj/structure/proc/find_key_for_door(mob/user)
+	if(!user || !keylock)
+		return null
+
+	// Try the inactive hand first
+	var/obj/item/O = user.get_inactive_held_item()
+	if(O && (istype(O, /obj/item/roguekey) || istype(O, /obj/item/storage/keyring)))
+		if(istype(O, /obj/item/roguekey))
+			var/obj/item/roguekey/K = O
+			if(K.lockhash == lockhash || istype(K, /obj/item/roguekey/lord))
+				return O
+		if(istype(O, /obj/item/storage/keyring))
+			if(keyring_has_matching_key(O))
+				return O
+
+	// Check possible key slots if human
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/list/key_slots = list(
+			H.get_item_by_slot(SLOT_RING),
+			H.get_item_by_slot(SLOT_NECK),
+			H.get_item_by_slot(SLOT_WRISTS),
+			H.get_item_by_slot(SLOT_BELT),
+			H.get_item_by_slot(SLOT_BELT_L),
+			H.get_item_by_slot(SLOT_BELT_R)
+		)
+
+		for(var/obj/item/I in key_slots)
+			if(!I) continue
+
+			// Check if the belt item itself is a key or keyring
+			if(istype(I, /obj/item/roguekey))
+				var/obj/item/roguekey/K = I
+				if(K.lockhash == lockhash || istype(K, /obj/item/roguekey/lord))
+					return I
+			if(istype(I, /obj/item/storage/keyring))
+				if(keyring_has_matching_key(I))
+					return I
+
+			// Check inside the belt item if it has contents (storage belts, etc.)
+			if(I.contents && I.contents.len)
+				for(var/obj/item/contained_item in I.contents)
+					if(istype(contained_item, /obj/item/roguekey))
+						var/obj/item/roguekey/K = contained_item
+						if(K.lockhash == lockhash || istype(K, /obj/item/roguekey/lord))
+							return I // Return the belt item that contains the key
+					if(istype(contained_item, /obj/item/storage/keyring))
+						if(keyring_has_matching_key(contained_item))
+							return I // Return the belt item that contains the keyring
+
+	return null
+
+/// Helper proc to check if a keyring on a mob contains a match for this structure's lockhash.
+/obj/structure/proc/keyring_has_matching_key(obj/item/storage/keyring/keyring)
+	if(!istype(keyring))
+		return FALSE
+
+	for(var/obj/item/I in keyring.contents)
+		if(istype(I, /obj/item/roguekey))
+			var/obj/item/roguekey/K = I
+			if(K.lockhash == lockhash)
+				return TRUE
+
+	return FALSE
+

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -13,7 +13,7 @@
 	var/secure = FALSE //secure locker or not, also used if overriding a non-secure locker with a secure door overlay to add fancy lights
 	var/opened = FALSE
 	var/welded = FALSE
-	var/locked = FALSE
+	locked = FALSE
 	var/large = TRUE
 	var/wall_mounted = 0 //never solid (You can always pass over it)
 	var/breakout_time = 1200
@@ -35,9 +35,9 @@
 	var/delivery_icon = "deliverycloset" //which icon to use when packagewrapped. null to be unwrappable.
 	var/anchorable = TRUE
 	var/icon_welded = "welded"
-	var/keylock = FALSE
-	var/lockhash
-	var/lockid = null
+	keylock = FALSE
+	lockhash = 0
+	lockid = null
 	var/masterkey = FALSE
 	var/lock_strength = 100
 	throw_speed = 1
@@ -288,31 +288,53 @@
 		to_chat(user, span_warning("There's no lock on this."))
 		return
 	if(obj_broken)
-		to_chat(user, span_warning("The lock is obj_broken."))
+		to_chat(user, span_warning("[src] is broken."))
 		return
-	if(istype(I,/obj/item/storage/keyring))
-		var/obj/item/storage/keyring/R = I
-		if(!R.contents.len)
-			return
-		var/list/keysy = shuffle(R.contents.Copy())
-		for(var/obj/item/roguekey/K in keysy)
-			if(user.cmode)
-				if(!do_after(user, 10, TRUE, src))
-					break
-			if(K.lockhash == lockhash)
-				togglelock(user)
-				break
-			else
-				if(user.cmode)
-					playsound(src, 'sound/foley/doors/lockrattle.ogg', 100)
-		return
-	else
+	user.changeNext_move(CLICK_CD_INTENTCAP)
+
+	if(istype(I, /obj/item/roguekey))
 		var/obj/item/roguekey/K = I
 		if(K.lockhash == lockhash || istype(K, /obj/item/roguekey/lord))
 			togglelock(user)
 			return
 		else
+			to_chat(user, span_warning("This is not the correct key."))
 			playsound(src, 'sound/foley/doors/lockrattle.ogg', 100)
+		return
+
+	// Handle belt items that contain keys
+	if(!istype(I, /obj/item/storage/keyring))
+		if(I.contents && I.contents.len)
+			var/obj/item/found_key = null
+			for(var/obj/item/contained_item in I.contents)
+				if(istype(contained_item, /obj/item/roguekey))
+					var/obj/item/roguekey/K = contained_item
+					if(K.lockhash == lockhash || istype(K, /obj/item/roguekey/lord))
+						found_key = contained_item
+						break
+				if(istype(contained_item, /obj/item/storage/keyring))
+					if(keyring_has_matching_key(contained_item))
+						found_key = contained_item
+						break
+
+			if(found_key)
+				// Use the found key instead of the belt
+				trykeylock(found_key, user)
+				return
+			else
+				to_chat(user, span_warning("No matching key found in [I]."))
+				playsound(src, 'sound/foley/doors/lockrattle.ogg', 100)
+				return
+
+	// The item I is a keyring
+	else
+		var/obj/item/storage/keyring/keyring = I
+		if(keyring_has_matching_key(keyring))
+			togglelock(user)
+			return
+		to_chat(user, span_warning("None of the keys on [keyring] can turn the lock."))
+		playsound(src, 'sound/foley/doors/lockrattle.ogg', 100)
+		return
 
 /obj/structure/closet/proc/trypicklock(obj/item/I, mob/user)
 	if(opened)
@@ -440,6 +462,26 @@
 		return
 	user.changeNext_move(CLICK_CD_INTENTCAP)
 	toggle(user)
+
+/obj/structure/closet/attack_right(mob/user)
+	user.changeNext_move(CLICK_CD_FAST)
+	
+	if(keylock)
+		var/obj/item/held_key = user.get_active_held_item()
+		if(istype(held_key, /obj/item/roguekey) || istype(held_key, /obj/item/storage/keyring))
+			trykeylock(held_key, user)
+			return
+		// Check if user has a key, either in the other hand, or within valid equipment slots
+		var/obj/item/key_item = find_key_for_door(user)
+		if(key_item)
+			trykeylock(key_item, user)
+			return
+		to_chat(user, span_warning("None of my equipped keys can turn the lock."))
+		playsound(src, 'sound/foley/doors/lockrattle.ogg', 100)
+	else
+		to_chat(user, span_warning("[src] doesn't have a lock."))
+	
+	return ..()
 
 /obj/structure/closet/attack_paw(mob/user)
 	return attack_hand(user)

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -8,7 +8,7 @@
 	armor = ARMOR_DISPLAYCASE
 	max_integrity = 150
 	integrity_failure = 0.33
-	var/locked = FALSE
+	locked = FALSE
 	var/open = TRUE
 	var/obj/item/rogueweapon/sword/long/heirloom
 

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -28,12 +28,14 @@
 	var/windowed = FALSE
 	var/base_state = null
 
-	var/locked = FALSE
+	locked = FALSE
 	var/last_bump = null
+	/// Used to help prevent double-toggling of the lock by accident (i.e. when bumping and clicking).
+	var/last_locktoggle = 0
 	var/brokenstate = 0
-	var/keylock = FALSE
-	var/lockhash = 0
-	var/lockid = null
+	keylock = FALSE
+	lockhash = 0
+	lockid = null
 	var/lockbroken = 0
 	var/locksound = 'sound/foley/doors/woodlock.ogg'
 	var/unlocksound = 'sound/foley/doors/woodlock.ogg'
@@ -364,7 +366,7 @@
 /obj/structure/mineral_door/attackby(obj/item/I, mob/user, autobump = FALSE)
 	user.changeNext_move(CLICK_CD_FAST)
 	if(istype(I, /obj/item/roguekey) || istype(I, /obj/item/storage/keyring))
-		if(!locked)
+		if(keylock && !locked)
 			to_chat(user, span_warning("It won't turn this way. Try turning to the right."))
 			door_rattle()
 			return
@@ -444,47 +446,40 @@
 
 /obj/structure/mineral_door/attack_right(mob/user)
 	user.changeNext_move(CLICK_CD_FAST)
-	var/obj/item = user.get_active_held_item()
-	if(istype(item, /obj/item/roguekey) || istype(item, /obj/item/storage/keyring))
-		if(locked)
-			to_chat(user, span_warning("It won't turn this way. Try turning to the left."))
-			door_rattle()
-			return
-		trykeylock(item, user)
-	else
+
+	// Skip key stuff for simple turn-deadbolt type doors, we don't have dual key-and-turn deadbolt functionality yet
+	if(istype(src, /obj/structure/mineral_door/wood/deadbolt))
 		return ..()
+
+	if(keylock)
+		var/obj/item/held_key = user.get_active_held_item()
+		if(istype(held_key, /obj/item/roguekey) || istype(held_key, /obj/item/storage/keyring))
+			trykeylock(held_key, user)
+			return
+		// Check if user has a key, either in the other hand, or within valid equipment slots
+		var/obj/item/key_item = find_key_for_door(user)
+		if(key_item)
+			trykeylock(key_item, user)
+			return
+		to_chat(user, span_warning("None of my equipped keys can turn the lock."))
+		door_rattle()
+	else
+		to_chat(user, span_warning("This door doesn't have a lock."))
+
+	return ..()
 
 /obj/structure/mineral_door/proc/trykeylock(obj/item/I, mob/user, autobump = FALSE)
 	if(door_opened || isSwitchingStates)
 		return
 	if(!keylock)
 		return
+	if((last_locktoggle + 0.2 SECONDS) > world.time)
+		return
 	if(lockbroken)
 		to_chat(user, span_warning("The lock to this door is broken."))
 	user.changeNext_move(CLICK_CD_INTENTCAP)
-	if(istype(I,/obj/item/storage/keyring))
-		var/obj/item/storage/keyring/R = I
-		if(!R.contents.len)
-			return
-		var/list/keysy = shuffle(R.contents.Copy())
-		for(var/obj/item/roguekey/K in keysy)
-			if(user.cmode)
-				if(!do_after(user, 10, TRUE, src))
-					break
-			if(K.lockhash == lockhash)
-				lock_toggle(user)
-				if(autobump && !locked)
-					src.Open()
-					addtimer(CALLBACK(src, PROC_REF(Close), FALSE, TRUE), 25)
-					src.last_bumper = user
-				return
-			else
-				if(user.cmode)
-					door_rattle()
-		to_chat(user, span_warning("None of the keys on my keyring go to this door."))
-		door_rattle()
-		return
-	else
+
+	if(istype(I, /obj/item/roguekey))
 		var/obj/item/roguekey/K = I
 		if(K.lockhash == lockhash || istype(K, /obj/item/roguekey/lord)) //master key cares not for lockhashes
 			lock_toggle(user)
@@ -494,8 +489,46 @@
 				src.last_bumper = user
 			return
 		else
-			to_chat(user, span_warning("This is not the correct key that goes to this door."))
+			to_chat(user, span_warning("This is not the correct key."))
 			door_rattle()
+			return
+
+	// Handle belt items that contain keys
+	if(!istype(I, /obj/item/storage/keyring))
+		if(I.contents && I.contents.len)
+			var/obj/item/found_key = null
+			for(var/obj/item/contained_item in I.contents)
+				if(istype(contained_item, /obj/item/roguekey))
+					var/obj/item/roguekey/K = contained_item
+					if(K.lockhash == lockhash || istype(K, /obj/item/roguekey/lord))
+						found_key = contained_item
+						break
+				if(istype(contained_item, /obj/item/storage/keyring))
+					if(keyring_has_matching_key(contained_item))
+						found_key = contained_item
+						break
+
+			if(found_key)
+				// Use the found key instead of the belt
+				trykeylock(found_key, user, autobump)
+				return
+			else
+				to_chat(user, span_warning("No matching key found in [I]."))
+				door_rattle()
+				return
+
+	// The item I is a keyring
+	else
+		var/obj/item/storage/keyring/keyring = I
+		if(keyring_has_matching_key(keyring))
+			lock_toggle(user)
+			if(autobump && !locked)
+				src.Open()
+				addtimer(CALLBACK(src, PROC_REF(Close), FALSE, TRUE), 25)
+				src.last_bumper = user
+			return
+		to_chat(user, span_warning("None of the keys on [keyring] can turn the lock."))
+		door_rattle()
 		return
 
 /obj/structure/mineral_door/proc/trypicklock(obj/item/I, mob/user)
@@ -570,6 +603,8 @@
 /obj/structure/mineral_door/proc/lock_toggle(mob/user)
 	if(isSwitchingStates || door_opened)
 		return
+	if((last_locktoggle + 0.2 SECONDS) > world.time)
+		return
 	if(locked)
 		user.visible_message(span_warning("[user] unlocks [src]."), \
 			span_notice("I unlock [src]."))
@@ -580,6 +615,7 @@
 			span_notice("I lock [src]."))
 		playsound(src, locksound, 100)
 		locked = 1
+	last_locktoggle = world.time
 
 /obj/structure/mineral_door/setAnchored(anchorvalue) //called in default_unfasten_wrench() chain
 	. = ..()

--- a/code/modules/roguetown/roguemachine/bathmaster.dm
+++ b/code/modules/roguetown/roguemachine/bathmaster.dm
@@ -11,11 +11,11 @@
 	anchored = TRUE
 	layer = BELOW_OBJ_LAYER
 	var/list/held_items = list()
-	var/locked = FALSE
+	locked = FALSE
 	var/budget = 0
 	var/upgrade_flags
 	var/current_cat = "1"
-	var/lockid = "nightman"
+	lockid = "nightman"
 	var/list/categories = list(
 		"Alcohols", 
 		"Drugs",

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -18,7 +18,7 @@
 	light_outer_range = 6
 	light_color = "#ff13d8ff"
 	var/list/held_items = list()
-	var/locked = FALSE
+	locked = FALSE
 	var/budget = 0
 	var/secret_budget = 0
 	var/recent_payments = 0

--- a/code/modules/roguetown/roguemachine/merchant/goldface.dm
+++ b/code/modules/roguetown/roguemachine/merchant/goldface.dm
@@ -23,11 +23,11 @@
 	anchored = TRUE
 	layer = BELOW_OBJ_LAYER
 	var/list/held_items = list()
-	var/locked = FALSE
+	locked = FALSE
 	var/budget = 0
 	var/upgrade_flags
 	var/current_cat = "1"
-	var/lockid = "merchant"
+	lockid = "merchant"
 	var/list/categories = list(
 		"Alcohols",
 		"Apparel",
@@ -133,6 +133,24 @@
 
 
 /obj/structure/roguemachine/goldface/attackby(obj/item/P, mob/user, params)
+	try_key_lock(P, user)
+
+	if(istype(P, /obj/item/roguecoin))
+		budget += P.get_real_price()
+		qdel(P)
+		update_icon()
+		playsound(loc, 'sound/misc/machinevomit.ogg', 100, TRUE, -1)
+		return attack_hand(user)
+	..()
+
+/obj/structure/roguemachine/goldface/attack_right(mob/user)
+	var/obj/item/P = user.get_active_held_item()
+	if(P)
+		try_key_lock(P, user)
+	..()
+
+/// Checks if the active hand contains the relevant key, then toggles the lock if so.
+/obj/structure/roguemachine/goldface/proc/try_key_lock(obj/item/P, mob/user)
 	if(istype(P, /obj/item/roguekey))
 		var/obj/item/roguekey/K = P
 		if(K.lockid == lockid)
@@ -155,13 +173,6 @@
 		if(!right_key)
 			to_chat(user, span_warning("Wrong key."))
 			return
-	if(istype(P, /obj/item/roguecoin))
-		budget += P.get_real_price()
-		qdel(P)
-		update_icon()
-		playsound(loc, 'sound/misc/machinevomit.ogg', 100, TRUE, -1)
-		return attack_hand(user)
-	..()
 
 /obj/structure/roguemachine/goldface/Topic(href, href_list)
 	. = ..()

--- a/code/modules/roguetown/roguemachine/steward/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward/steward.dm
@@ -16,7 +16,7 @@
 	max_integrity = 0
 	anchored = TRUE
 	layer = BELOW_OBJ_LAYER
-	var/locked = FALSE
+	locked = FALSE
 	var/keycontrol = "steward"
 	var/current_tab = TAB_MAIN
 	var/compact = TRUE

--- a/code/modules/roguetown/roguemachine/vendor.dm
+++ b/code/modules/roguetown/roguemachine/vendor.dm
@@ -10,7 +10,7 @@
 	anchored = TRUE
 	layer = BELOW_OBJ_LAYER
 	var/list/held_items = list()
-	var/locked = TRUE
+	locked = TRUE
 	var/budget = 0
 	var/wgain = 0
 	var/keycontrol = "merchant"

--- a/modular/code/game/objects/pillory.dm
+++ b/modular/code/game/objects/pillory.dm
@@ -14,9 +14,9 @@
 	layer = ABOVE_ALL_MOB_LAYER
 	plane = GAME_PLANE_UPPER
 	var/latched = FALSE
-	var/locked = FALSE
+	locked = FALSE
 	var/base_icon = "pillory_single"
-	var/list/lockid = list()
+	var/list/lockids = list()
 
 /obj/structure/pillory/double
 	icon_state = "pillory_double"
@@ -27,16 +27,16 @@
 	base_icon = "pillory_reinforced"
 
 /obj/structure/pillory/town_square
-	lockid = list("keep_dungeon", "keep_barracks", "town_dungeon", "town_barracks", "bog_dungeon", "bog_barracks", "church")
+	lockids = list("keep_dungeon", "keep_barracks", "town_dungeon", "town_barracks", "bog_dungeon", "bog_barracks", "church")
 
 /obj/structure/pillory/reinforced/keep_dungeon
-	lockid = list("keep_dungeon")
+	lockids = list("keep_dungeon")
 
 /obj/structure/pillory/reinforced/town_dungeon
-	lockid = list("town_dungeon")
+	lockids = list("town_dungeon")
 
 /obj/structure/pillory/reinforced/bog_dungeon
-	lockid = list("bog_dungeon")
+	lockids = list("bog_dungeon")
 
 
 /obj/structure/pillory/Initialize()
@@ -71,7 +71,7 @@
 		return
 	if(istype(P, /obj/item/roguekey))
 		var/obj/item/roguekey/K = P
-		if(K.lockid in lockid)
+		if(K.lockid in lockids)
 			togglelock(user)
 			return
 		else
@@ -81,7 +81,7 @@
 	if(istype(P, /obj/item/storage/keyring))
 		var/obj/item/storage/keyring/K = P
 		for(var/obj/item/roguekey/KE in K.keys)
-			if(KE.lockid in lockid)
+			if(KE.lockid in lockids)
 				togglelock(user)
 				return
 


### PR DESCRIPTION
## About The Pull Request
Add right-click lock/unlock to doors. generalize key/lock variables to /obj

This is part copypaste from newer code, part refactor of the copypasted code.

I had a bunch of shit written out, but sadly most of it got eaten after I closed the tab. So I'll give the short version for now, and maybe edit it later. Check Changelog section.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I took a lot of time to make sure this worked the way I wanted it to. Other existing lock things (vendors!) were similarly tested to make sure they still lock/unlock properly.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Makes interacting with doors a lot smoother and more intuitive, when they necessarily need to be. Locking and unlocking does NOT need that many clicks.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

```
- Right clicking now works to both lock and unlock on doors, chests, and closets. Left clicking still works for unlocking, but not for locking.
- If you have keys equipped, they can be used to lock and unlock without holding them in-hand. You do this using right click when they're in the appropriate equipment slot.
  - Checked slots: ring, neck, wrists, belt slot, hip slots. Bags in these slots will also be checked to see if they have the correct key.
- You will still only trigger door bump-unlocking (walking into it) if you're holding the key in your hand.
- Made messages informative regarding failed attempts to lock/unlock these objects.
```