### PR TITLE
Make music radio areas use a silent sound instead of nothing

### DIFF
--- a/code/game/area/temp13/factionbases.dm
+++ b/code/game/area/temp13/factionbases.dm
@@ -11,9 +11,9 @@
 /area/rogue/outdoors/indoors/persunbaseoutlook // for jukeboxes
 	name = "perserdun outdoors"
 	icon_state = "town"
-	droning_sound = null
-	droning_sound_dusk = null
-	droning_sound_night = null
+	droning_sound = 'sound/silence.ogg'
+	droning_sound_dusk = 'sound/silence.ogg'
+	droning_sound_night = 'sound/silence.ogg'
 	converted_type = /area/rogue/outdoors/exposed/town
 
 /area/rogue/outdoors/exposed/perserdunbase
@@ -36,9 +36,9 @@
 /area/rogue/indoors/risvonbasebar
 	name = "risvon indoors"
 	icon_state = "town"
-	droning_sound = null
-	droning_sound_dusk = null
-	droning_sound_night = null
+	droning_sound = 'sound/silence.ogg'
+	droning_sound_dusk = 'sound/silence.ogg'
+	droning_sound_night = 'sound/silence.ogg'
 	converted_type = /area/rogue/outdoors/exposed/town
 	town_area = TRUE
 


### PR DESCRIPTION
## About The Pull Request
Fixes these rooms breaking other sound stuff, like combat mode toggling, for as long as you were inside.

The system is not made to accept `null` for a sound filepath. Setting these to `null` made it so that the "droning" background music wouldn't stop when you entered the room, and neither would combat music.

Though making these rooms just quiet-by-default probably isn't the best approach, considering radios can be moved. Maybe we should have these radios just fade out the droning music for as long as you're in range.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I spawned as commandant and toggled combat music on and off, walking in and out of my room. Then I listened to Promiscuous.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fixes a sound bug
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
