### PR TITLE
NOBODY CARES ABOUT BISHOP (Fixes Global Perserdun list to have bishop in it)

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -183,7 +183,7 @@ GLOBAL_LIST_INIT(test_positions, list(
 GLOBAL_LIST_INIT(perserdun_positions, list(
 	"Grandmaster",
 	"Grand Knight",
-	"War Priest",
+	"Field Bishop",
 	"Knight Commander",
 	"Voltigeur",
 	"Armsman",


### PR DESCRIPTION
## About The Pull Request

The way the code works you're only part of a factionn in the actors list and what have you if you're in the joblist and uh, "Field Bishop" isn't in that list but "War Priest" is. This fixes that.

## Testing Evidence

<img width="441" height="101" alt="image" src="https://github.com/user-attachments/assets/591129b0-fae8-4abc-b22a-5c20dea64bc8" />

<img width="365" height="407" alt="image" src="https://github.com/user-attachments/assets/0ad2e2dc-f72b-43a2-b0fb-f75e688669ab" />


## Why It's Good For The Game

Bug bad. Fix good.
