### PR TITLE
BLOWS UP PANCAKES WITH MIND (Grenade Merchant Category Fix/expansion)

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/t13/grenades.dm
+++ b/code/modules/cargo/packsrogue/merchant/t13/grenades.dm
@@ -6,20 +6,31 @@
 /datum/supply_pack/rogue/grenades/smoke
 	name = "Smoke Grenades (x3)"
 	cost = 20
-	contains = list(/obj/item/grenade/gas/smoke, 
-	/obj/item/grenade/gas/smoke, 
+	contains = list(/obj/item/grenade/gas/smoke,
+	/obj/item/grenade/gas/smoke,
 	/obj/item/grenade/gas/smoke)
 
 /datum/supply_pack/rogue/grenades/gas
 	name = "Gas Grenades (x3)"
 	cost = 60
-	contains = list(/obj/item/grenade/gas/poison, 
+	contains = list(/obj/item/grenade/gas/poison,
 	/obj/item/grenade/gas/poison,
 	/obj/item/grenade/gas/poison)
 
-/datum/supply_pack/rogue/grenades/highexplosive
-	name = "High-Explosive Grenades (x3)"
+/datum/supply_pack/rogue/grenades/frag
+	name = "Fragmentation Grenades (x3)"
 	cost = 65
-	contains = list(/obj/item/grenade, 
-	/obj/item/grenade, 
-	/obj/item/grenade)
+	contains = list(/obj/item/grenade/frag,
+	/obj/item/grenade/frag,
+	/obj/item/grenade/frag)
+
+/datum/supply_pack/rogue/grenades/dynamite
+	name = "Dynamite (x2)"
+	cost = 60
+	contains = list(/obj/item/bomb/dynamite,
+	/obj/item/bomb/dynamite)
+
+/datum/supply_pack/rogue/grenades/satchel
+	name = "Satchel Charge"
+	cost = 60
+	contains = list(/obj/item/bomb/satchel)


### PR DESCRIPTION
## About The Pull Request

Adds Dynamite and Satchel Charges to GRENADE section of vendors. Fixes broken HE grenade vending

## Testing Evidence


https://github.com/user-attachments/assets/777f64ab-8ca7-451e-8192-059bcfe53305


## Why It's Good For The Game

Dad asked for it
