### PR TITLE
Allows lanterns to be put on Neck_Slot

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -301,7 +301,7 @@
 	light_outer_range = 5
 	on = FALSE
 	flags_1 = CONDUCT_1
-	slot_flags = ITEM_SLOT_HIP
+	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_NECK
 	obj_flags = CAN_BE_HIT
 	force = 1
 	on_damage = 5
@@ -401,7 +401,7 @@
 	desc = "A simple and cheap lantern."
 	on = FALSE
 	flags_1 = CONDUCT_1
-	slot_flags = ITEM_SLOT_HIP
+	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_NECK
 	force = 1
 	on_damage = 5
 	fuel = 120 MINUTES


### PR DESCRIPTION
## About The Pull Request

Changes the way belt slots are open to other things, instead of taking a lantern out of a container and back over and over again, it makes it so you can just leave it on the neck slot and not worry about it. 


## Why It's Good For The Game

Ideally I want to put a trench axe, and a pistol on my belt slot. Lanterns have always been coded this way so other people may see it differently.
