### PR TITLE
Loadout additions and gas mask and hood changes!

### DIFF
--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -1713,8 +1713,8 @@
 	AddComponent(/datum/component/storage/concrete/roguetown/cloak)
 
 /obj/item/clothing/cloak/forrestercloak/snow
-	name = "snow cloak"
-	desc = "A cloak meant to keep one's body warm in the cold of the mountains as well as the dampness of Azuria."
+	name = "shortcloak"
+	desc = "A cloak meant to keep one's body warm in the cold of the mountains as well as the dampness of TEMPERANCE."
 	icon_state = "snowcloak"
 
 //eastern update

--- a/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
+++ b/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
@@ -12,7 +12,7 @@
 	alternate_worn_layer  = 8.9 //On top of helmet
 	body_parts_covered = NECK|HAIR|EARS|HEAD
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
-	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK
+	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK|ITEM_SLOT_NECK
 	sleevetype = null
 	sleeved = null
 	dynamic_hair_suffix = ""

--- a/code/modules/clothing/rogueclothes/headwear/otherhoods.dm
+++ b/code/modules/clothing/rogueclothes/headwear/otherhoods.dm
@@ -103,6 +103,9 @@
 	desc = "A hood commonly worn by executioners to hide their face; The stigma of such a role, and all the grisly work it entails, makes many executioners outcasts in their own right."
 	icon_state = "menacing"
 	item_state = "menacing"
+	icon = 'icons/roguetown/clothing/head.dmi'
+	mob_overlay_icon = 'icons/roguetown/clothing/onmob/head.dmi' //Overrides slot icon behavior
+	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK|ITEM_SLOT_NECK
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	dynamic_hair_suffix = ""
 	sewrepair = TRUE

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -408,6 +408,7 @@
 	name = "old gas mask"
 	desc = "A locally-produced gas mask. Comes with a tube, and box."
 	icon_state = "EB_gasmask"
+	flags_inv = HIDEFACE|HIDESNOUT|HIDEFACIALHAIR
 
 /obj/item/clothing/mask/rogue/gasmask/perserdunmask
 	name = "tubed gas mask"

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -104,6 +104,14 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Heavy Hood"
 	path = /obj/item/clothing/head/roguetown/roguehood/shalal/heavyhood
 
+/datum/loadout_item/sackhood
+    name = "Sackhood"
+    path = /obj/item/clothing/head/roguetown/menacing/
+
+/datum/loadout_item/bandithood
+	name = "Bandit Sackhood"
+	path = /obj/item/clothing/head/roguetown/menacing/bandit
+
 /datum/loadout_item/nunveil
 	name = "Nun Veil"
 	path = /obj/item/clothing/head/roguetown/nun
@@ -129,6 +137,10 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Cape"
 	path = /obj/item/clothing/cloak/cape
 
+/datum/loadout_item/shortcloak
+	name = "Shortcloak"
+	path = /obj/item/clothing/cloak/forrestercloak/snow
+
 /datum/loadout_item/halfcloak
 	name = "Halfcloak"
 	path = /obj/item/clothing/cloak/half
@@ -145,6 +157,9 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Rapscallion's Shawl"
 	path = /obj/item/clothing/cloak/thief_cloak
 
+/datum/loadout_item/longcoat
+	name = "Longcoat"
+	path = /obj/item/clothing/suit/roguetown/armor/longcoat
 //SHOES
 /datum/loadout_item/darkboots
 	name = "Dark Boots"


### PR DESCRIPTION


## About The Pull Request
This adds 3 new items to the loadout selection:
- Longcoats
- Shortcloaks(This is NOT the noble version, just the snow cloak renamed)
- Sackhoods(Regular and the bandit version)

It also makes it so hoods(and the sack variety) can be worn on the neckslot. The sackhoods can look a little goofy when worn like this.

Lastly, the old gas mask that is found in the machines(and the Blackguard) now doesn't make you bald anymore. Super sexy.

## Testing Evidence
worked fine
<img width="109" height="109" alt="grafik" src="https://github.com/user-attachments/assets/855994ff-b77f-47e5-9345-bab9f05e695f" />
<img width="146" height="158" alt="grafik" src="https://github.com/user-attachments/assets/17c3415f-0df0-4a8d-bf64-ae99096a9757" />
also look at the gas mask change. sexy!
<img width="83" height="88" alt="grafik" src="https://github.com/user-attachments/assets/aa71fe79-777d-4215-a2e4-d207c143ef78" />
<img width="71" height="95" alt="grafik" src="https://github.com/user-attachments/assets/cb9aa623-df0d-4694-a1cf-387db4d72bcd" />
<img width="136" height="144" alt="grafik" src="https://github.com/user-attachments/assets/b038960b-a551-49ea-84eb-a38ff24ed428" />
<img width="134" height="117" alt="grafik" src="https://github.com/user-attachments/assets/78860c13-9156-4f6e-b5ee-ab84d15d3543" />
<img width="118" height="144" alt="grafik" src="https://github.com/user-attachments/assets/409df5e7-985d-4fe4-8bef-f97b06a47d0d" />


## Why It's Good For The Game
More loadout options are always nice. We like to look good. And the sprite for the hood technically goes around the neck, so it makes sense.
