### PR TITLE
Fixes & optimization for scon 2 port

### DIFF
--- a/code/datums/sexcon/sex_actions/deviant/grinding.dm
+++ b/code/datums/sexcon/sex_actions/deviant/grinding.dm
@@ -38,7 +38,7 @@
 	user.sexcon.show_progress = !do_subtle
 	user.sexcon.suppress_moan = target.sexcon.suppress_moan = do_subtle
 
-	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] grinds over [target]'s [zone_text]..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective(is_stealth = do_subtle)] grinds over [target]'s [zone_text]..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
 	if(!do_subtle)
 		if(user.sexcon.force > SEX_FORCE_HIGH)
 			user.sexcon.outercourse_noise(target)

--- a/code/datums/sexcon/sex_actions/masturbate/masturbate_anus.dm
+++ b/code/datums/sexcon/sex_actions/masturbate/masturbate_anus.dm
@@ -26,7 +26,7 @@
 	user.sexcon.show_progress = !do_subtle
 	user.sexcon.suppress_moan = do_subtle
 
-	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fingers [user.p_their()] butt..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective(is_stealth = do_subtle)] fingers [user.p_their()] butt..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
 	if(!do_subtle)
 		user.sexcon.generic_sex_noise()
 

--- a/code/datums/sexcon/sex_actions/masturbate/masturbate_breasts.dm
+++ b/code/datums/sexcon/sex_actions/masturbate/masturbate_breasts.dm
@@ -28,7 +28,7 @@
 	user.sexcon.show_progress = !do_subtle
 	user.sexcon.suppress_moan = do_subtle
 
-	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fondles [user.p_their()] breasts..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective(is_stealth = do_subtle)] fondles [user.p_their()] breasts..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
 
 	user.sexcon.perform_sex_action(user, 1, 4, TRUE)
 	user.sexcon.handle_passive_ejaculation()

--- a/code/datums/sexcon/sex_actions/masturbate/masturbate_other_anus.dm
+++ b/code/datums/sexcon/sex_actions/masturbate/masturbate_other_anus.dm
@@ -26,7 +26,7 @@
 	user.sexcon.show_progress = !do_subtle
 	user.sexcon.suppress_moan = target.sexcon.suppress_moan = do_subtle
 
-	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fingers [target]'s butt..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective(is_stealth = do_subtle)] fingers [target]'s butt..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
 	if(!do_subtle)
 		user.sexcon.generic_sex_noise()
 

--- a/code/datums/sexcon/sex_actions/masturbate/masturbate_other_breasts.dm
+++ b/code/datums/sexcon/sex_actions/masturbate/masturbate_other_breasts.dm
@@ -29,7 +29,7 @@
 	user.sexcon.show_progress = !do_subtle
 	user.sexcon.suppress_moan = target.sexcon.suppress_moan = do_subtle
 
-	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fondles [target]'s breasts..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective(is_stealth = do_subtle)] fondles [target]'s breasts..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
 
 	user.sexcon.perform_sex_action(target, 1, 4, TRUE)
 	target.sexcon.handle_passive_ejaculation()

--- a/code/datums/sexcon/sex_actions/masturbate/masturbate_other_penis.dm
+++ b/code/datums/sexcon/sex_actions/masturbate/masturbate_other_penis.dm
@@ -31,7 +31,7 @@
 	user.sexcon.suppress_moan = target.sexcon.suppress_moan = do_subtle
 
 	var/chosen_verb = pick(list("jerks [target]'s cock", "strokes [target]'s cock", "masturbates [target]", "jerks off [target]"))
-	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] [chosen_verb]..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective(is_stealth = do_subtle)] [chosen_verb]..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
 	if(!do_subtle)
 		user.sexcon.generic_sex_noise()
 

--- a/code/datums/sexcon/sex_actions/masturbate/masturbate_other_vagina.dm
+++ b/code/datums/sexcon/sex_actions/masturbate/masturbate_other_vagina.dm
@@ -30,7 +30,7 @@
 	user.sexcon.show_progress = !do_subtle
 	user.sexcon.suppress_moan = target.sexcon.suppress_moan = do_subtle
 
-	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] strokes [target]'s clit..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective(is_stealth = do_subtle)] strokes [target]'s clit..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
 	if(!do_subtle)
 		user.sexcon.generic_sex_noise()
 

--- a/code/datums/sexcon/sex_actions/masturbate/masturbate_other_vagina_finger.dm
+++ b/code/datums/sexcon/sex_actions/masturbate/masturbate_other_vagina_finger.dm
@@ -30,7 +30,7 @@
 	user.sexcon.show_progress = !do_subtle
 	user.sexcon.suppress_moan = target.sexcon.suppress_moan = do_subtle
 
-	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fingers [target]'s [pick("slit","cunt","pussy","snatch")]..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective(is_stealth = do_subtle)] fingers [target]'s [pick("slit","cunt","pussy","snatch")]..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
 	if(!do_subtle)
 		user.sexcon.generic_sex_noise()
 

--- a/code/datums/sexcon/sex_actions/masturbate/masturbate_penis.dm
+++ b/code/datums/sexcon/sex_actions/masturbate/masturbate_penis.dm
@@ -33,7 +33,7 @@
 	user.sexcon.suppress_moan = do_subtle
 
 	var/chosen_verb = pick(list("jerks [user.p_their()] cock", "strokes [user.p_their()] cock", "masturbates", "jerks off"))
-	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] [chosen_verb]..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective(is_stealth = do_subtle)] [chosen_verb]..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
 	if(!do_subtle)
 		user.sexcon.generic_sex_noise()
 

--- a/code/datums/sexcon/sex_actions/masturbate/masturbate_vagina.dm
+++ b/code/datums/sexcon/sex_actions/masturbate/masturbate_vagina.dm
@@ -30,7 +30,7 @@
 	user.sexcon.show_progress = !do_subtle
 	user.sexcon.suppress_moan = do_subtle
 
-	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] strokes [user.p_their()] clit..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective(is_stealth = do_subtle)] strokes [user.p_their()] clit..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
 	if(!do_subtle)
 		user.sexcon.generic_sex_noise()
 

--- a/code/datums/sexcon/sex_actions/masturbate/masturbate_vagina_finger.dm
+++ b/code/datums/sexcon/sex_actions/masturbate/masturbate_vagina_finger.dm
@@ -30,7 +30,7 @@
 	user.sexcon.show_progress = !do_subtle
 	user.sexcon.suppress_moan = do_subtle
 
-	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fingers [user.p_their()] [pick("slit","cunt","pussy","snatch")]..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective(is_stealth = do_subtle)] fingers [user.p_their()] [pick("slit","cunt","pussy","snatch")]..."), vision_distance = (do_subtle ? 1 : DEFAULT_MESSAGE_RANGE))
 	if(!do_subtle)
 		user.sexcon.generic_sex_noise()
 

--- a/code/datums/sexcon/sexcon.dm
+++ b/code/datums/sexcon/sexcon.dm
@@ -76,6 +76,13 @@
 	var/bottom_exposed = FALSE
 	/// Allow chest to be exposed and show breasts
 	var/top_exposed = FALSE
+	// Moved here from proc/get_generic_force_adjective to reduce list initialization/destruction
+	var/static/list/stealth_force_adjectives 	= list("subtly", "sneakily", "covertly", "stealthily", "quietly")
+	var/static/list/low_force_adjectives 		= list("gently", "carefully", "tenderly", "gingerly", "delicately", "lazily")
+	var/static/list/mid_force_adjectives 		= list("firmly", "vigorously", "eagerly", "steadily", "intently")
+	var/static/list/high_force_adjectives 		= list("roughly", "carelessly", "forcefully", "fervently", "fiercely")
+	var/static/list/extreme_force_adjectives 	= list("brutally", "violently", "relentlessly", "savagely", "mercilessly")
+	var/static/list/ludicrous_force_adjectives 	= list("madly", "uncontrollably", "desperately", "deliriously", "freekishly")
 
 /datum/sex_controller/New(mob/living/carbon/human/owner)
 	user = owner
@@ -1152,18 +1159,18 @@
 
 /datum/sex_controller/proc/get_generic_force_adjective(is_stealth = FALSE)
 	if(is_stealth)
-		return pick(list("subtly","sneakily","covertly","stealthily","quietly"))
+		return pick(stealth_force_adjectives)
 	switch(force)
 		if(SEX_FORCE_LOW)
-			return pick(list("gently", "carefully", "tenderly", "gingerly", "delicately", "lazily"))
+			return pick(low_force_adjectives)
 		if(SEX_FORCE_MID)
-			return pick(list("firmly", "vigorously", "eagerly", "steadily", "intently"))
+			return pick(mid_force_adjectives)
 		if(SEX_FORCE_HIGH)
-			return pick(list("roughly", "carelessly", "forcefully", "fervently", "fiercely"))
+			return pick(high_force_adjectives)
 		if(SEX_FORCE_EXTREME)
-			return pick(list("brutally", "violently", "relentlessly", "savagely", "mercilessly"))
+			return pick(extreme_force_adjectives)
 		if(SEX_FORCE_LUDICROUS)
-			return pick(list("madly", "uncontrollably", "desperately", "deliriously", "freekishly"))
+			return pick(ludicrous_force_adjectives)
 
 /datum/sex_controller/proc/spanify_force(string)
 	switch(force)

--- a/code/datums/sexcon/sexcon.dm
+++ b/code/datums/sexcon/sexcon.dm
@@ -1150,7 +1150,9 @@
 		if(SEX_MANUAL_AROUSAL_FULL)
 			return "<font color='#d146f5'>FULLY ERECT</font>"
 
-/datum/sex_controller/proc/get_generic_force_adjective()
+/datum/sex_controller/proc/get_generic_force_adjective(is_stealth = FALSE)
+	if(is_stealth)
+		return pick(list("subtly","sneakily","covertly","stealthily","quietly"))
 	switch(force)
 		if(SEX_FORCE_LOW)
 			return pick(list("gently", "carefully", "tenderly", "gingerly", "delicately", "lazily"))

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -519,6 +519,7 @@ h1.alert, h2.alert	{color: #c9c1ba;font-family: Pterra, TrueType;}
 .love_mid					{color: #e9a8d1;	font-size: 75%;}
 .love_high					{color: #f05ee1;	font-size: 75%;}
 .love_extreme					{color: #d146f5;	font-size: 75%;}
+.love_ludicrous					{color: #d61a43;	font-size: 75%;}
 /*
 @keyframes hypnocolor {
 	0%		{color: #202020;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -191,4 +191,5 @@ h1.alert, h2.alert	{color: #c9c1ba;font-family: Pterra, TrueType;}
 .love_mid					{color: #e9a8d1;	font-size: 75%;}
 .love_high					{color: #f05ee1;	font-size: 75%;}
 .love_extreme					{color: #d146f5;	font-size: 75%;}
+.love_ludicrous					{color: #d61a43;	font-size: 75%;}
 </style>"}


### PR DESCRIPTION
## About The Pull Request
Cynical disappeared all of a sudden, so here I am, fixing sex.

- `/datum/sex_controller/proc/get_generic_force_adjective` now has the proper stealth stuff in it, he forgot to copypaste it from Ratwood and it caused both runtime errors and dreamchecker errors. All good now.
- Adding the `.love_ludicrous` span class to chat CSS was also overlooked. Fixed now. Ludicrous force will now be properly formatted.
- Reverts #187 as it broke stealth behavior to fix runtimes from the first oversight.
- Optimizes force adjective picking by using static list vars, instead of initializing a list to pick from (and destroying it) every single time. Now the lists will only be initialized once, at startup.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<details>
<summary>I'm sorry.</summary>
<img width="570" height="1373" alt="image" src="https://github.com/user-attachments/assets/b5b0267c-697f-4295-bef1-1235a233a5f8" />
</details>

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Dick works
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
