### PR TITLE
reviver exploit fix

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/t13/organs.dm
+++ b/code/modules/cargo/packsrogue/merchant/t13/organs.dm
@@ -31,7 +31,7 @@
 /datum/supply_pack/rogue/organs/reviver
 	name = "REVIVER"
 	cost = 10
-	contains = list(/obj/item/reagent_containers/lux)
+	contains = list(/obj/item/reagent_containers/lux/cheap)
 
 /datum/supply_pack/rogue/organs/health
 	name = "HEALTH (x2)"

--- a/modular_hearthstone/code/modules/reagents/reagent_containers/lux.dm
+++ b/modular_hearthstone/code/modules/reagents/reagent_containers/lux.dm
@@ -28,3 +28,8 @@
 		M.sate_addiction()
 	M.apply_status_effect(/datum/status_effect/buff/vitae)
 	..()
+
+/obj/item/reagent_containers/lux/cheap
+	name = "REVIVER"
+	desc = "This ugly little thing latches onto someone's heart, and produces life. This one has seen better days and likely sat far to long in storage. Doubtful buyers would care for it. Though still serviceable."
+	sellprice = 3 


### PR DESCRIPTION
## About The Pull Request
This PR fixes a fairly massive exploit. Effectively you could buy revivers and then cart them to the Provisioner to print endless mammon at a frankly absurd rate! 60-90 mammon PER reviver.

This PR fixes that by adding a second ''cheap'' reviver to the organ venders. virtually identical but with a tanked sell price.

And oft chance you are wondering. No one that I know of figured this out yet and started doing it in mass at least.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested the new ''cheap'' revivers still work in surgery and appear in the 2 types of organ vender.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
You might ask why not just nerf the base reviver? 
Well! I still think medical enjoyers should be able to setup reviver harvesting to produce money if they chose. (it's actually amazing fucking money when you have 50 meatheads with guns to harvest from)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
