### PR TITLE
Add Xiaoren to non-combatant races

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -212,7 +212,26 @@
 	/datum/species/human/halfelf,\
 )
 
+#define RACES_CONSCRIPT list(\
+	/datum/species/human/northern,\
+	/datum/species/elf/wood,\
+	/datum/species/demihuman,\
+	/datum/species/tieberian,\
+	/datum/species/anthromorph,\
+	/datum/species/human/halfelf,\
+)
+
 #define RACES_TEMPERANCE_NONCOMBATANT list(\
+	/datum/species/human/northern,\
+	/datum/species/elf/wood,\
+	/datum/species/demihuman,\
+	/datum/species/anthromorph,\
+	/datum/species/tieberian,\
+	/datum/species/human/halfelf,\
+	/datum/species/construct/metal/porcelain,\
+)
+
+#define RACES_TEMPERANCE_BATTLEMEDIC list(\
 	/datum/species/human/northern,\
 	/datum/species/elf/wood,\
 	/datum/species/demihuman,\

--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -216,6 +216,7 @@
 	/datum/species/human/northern,\
 	/datum/species/elf/wood,\
 	/datum/species/demihuman,\
+	/datum/species/anthromorph,\
 	/datum/species/tieberian,\
 	/datum/species/human/halfelf,\
 	/datum/species/construct/metal/porcelain,\


### PR DESCRIPTION
## About The Pull Request
Effectively unlocks the following roles for Xiaoren: Chirurgeon, Consulo, Curacisto, Provisioner, Mortician.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Webedit
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I like playing medical and would appreciate not getting shut out of *the* medical roles
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
