### PR TITLE
Add Xiaoren to non-combatant races, add Nietzschka to Auxiliarist and Magiisto

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -217,6 +217,17 @@
 	/datum/species/elf/wood,\
 	/datum/species/demihuman,\
 	/datum/species/tieberian,\
+	/datum/species/anthromorph,\
+	/datum/species/human/halfelf,\
+	/datum/species/construct/metal/porcelain,\
+)
+
+#define RACES_TEMPERANCE_BATTLEMEDICS list(\
+	/datum/species/human/northern,\
+	/datum/species/elf/wood,\
+	/datum/species/demihuman,\
+	/datum/species/tieberian,\
+	/datum/species/anthromorph,\
 	/datum/species/human/halfelf,\
 	/datum/species/construct/metal/porcelain,\
 )

--- a/code/modules/jobs/job_types/roguetown/perserdunian/auxiliar.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/auxiliar.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 4
 	spawn_positions = 4
-	allowed_races = RACES_CONSCRIPT
+	allowed_races = RACES_TEMPERANCE_BATTLEMEDICS
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 

--- a/code/modules/jobs/job_types/roguetown/risvonian/servisto.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/servisto.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
-	allowed_races = RACES_CONSCRIPT
+	allowed_races = RACES_TEMPERANCE_BATTLEMEDICS
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 


### PR DESCRIPTION
## About The Pull Request
Effectively unlocks the following roles for Xiaoren: Chirurgeon, Consulo, Curacisto, Provisioner, Mortician.
Also bundling in DrDogs' proposal to avoid merge conflicts: adds Nietzschka to Auxiliarist and Magiisto.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="464" height="202" alt="image" src="https://github.com/user-attachments/assets/309bb139-7236-4c24-881f-05cda8f52f24" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I like playing medical and would appreciate not getting shut out of the medical roles
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
