### PR TITLE
Allows furries (demihumans too) to be GK/GM/CHIR

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/helmet/light_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/light_helmet.dm
@@ -172,4 +172,3 @@
 	blocksound = SOFTHIT
 	max_integrity = ARMOR_INT_HELMET_CLOTH
 	color = null
-	resistance_flags = FIRE_PROOF

--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -638,7 +638,6 @@
 	desc = "An expensive piece of equipment that connects straight to AS-Y14 through the use of radio waves."
 	icon_state = "radiopack"
 	item_state = "radiopack"
-	resistance_flags = FIRE_PROOF
 	var/list/radiostatic_sounds = list('sound/foley/radiostatic/badopera.ogg', 'sound/foley/radiostatic/beep.ogg', 'sound/foley/radiostatic/ditditdit.ogg', 'sound/foley/radiostatic/hangup.ogg', 'sound/foley/radiostatic/malechatter.ogg', 'sound/foley/radiostatic/roger.ogg', 'sound/foley/radiostatic/standby.ogg', 'sound/foley/radiostatic/thinking.ogg')
 
 /obj/item/storage/backpack/rogue/satchel/radiopack/Initialize()

--- a/code/modules/jobs/job_types/roguetown/perserdunian/radiotrooper.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/radiotrooper.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 0
 	spawn_positions = 0
-	allowed_races = RACES_CONSCRIPT
+	allowed_races = RACES_TEMPERANCE
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 


### PR DESCRIPTION

This is an attempt to get people to play GK/GM/CHIR more. Right now after POST MORRIS there are literally 0 GM players. Envoys can already be furries, too. There are also like 3 ppl who play GK in total. 

I WANT PEOPLE TO MAKE UNIQUE FURRY CHARACTERS DEDICATED TO GM/GK/CHIR IF THEY ARE GOING TO PLAY THE ROLE. MAKE A CHARACTER THAT MAKES SENSE AS A LEADER. DON'T MAKE A THICK-THIGHED RAPEBAIT TWINK AND PLAY GK AS IT!!!!!!!! FUCK!!! MAKE A STRONG ANIMAL LEADER, LIKE AN OX

we'll see if this works or not. before all the role-additions to RIVS, this worked for them. 