### PR TITLE
Reviver exploit fix take 2

### DIFF
--- a/modular_hearthstone/code/modules/reagents/reagent_containers/lux.dm
+++ b/modular_hearthstone/code/modules/reagents/reagent_containers/lux.dm
@@ -8,7 +8,7 @@
 	volume = 15
 	list_reagents = list(/datum/reagent/vitae = 5)
 	grind_results = list(/datum/reagent/vitae = 5)
-	sellprice = 90
+	sellprice = 3
 
 /datum/reagent/vitae
 	name = "Vitae"


### PR DESCRIPTION
look I'll skip format it's a oneliner exploit fix. Just go look at #204 for details.

Tanks the cost of revivers to nearly nothing to prevent money printing.