### PR TITLE
AT THE BARBERSHOP (Hair uncovered by default Grandmaster helmet)

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/helmet/t13helmets.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/t13helmets.dm
@@ -88,11 +88,12 @@
 /obj/item/clothing/head/roguetown/helmet/leather/grandmaster
 	name = "master's cap"
 	desc = "A handcrafted cap, following the fashion style produced by the LOVE MACHINE. Has a metal plate on the front."
+	body_parts_covered = HEAD
 	icon_state = "grandhat"
 	item_state = "grandhat"
 	experimental_inhand = FALSE
 	experimental_onhip = FALSE
-	flags_inv = HIDE_HEADTOP
+	flags_inv = null
 
 /obj/item/clothing/head/roguetown/helmet/leather/envoy
 	name = "envoy's cap"


### PR DESCRIPTION
## About The Pull Request

Makes grandmaster hat not cover hair by default. You can still have it cover your hair by MMB clicking it.

## Testing Evidence

<img width="270" height="319" alt="image" src="https://github.com/user-attachments/assets/e3c81ec4-faa1-487a-9785-c4157072efae" />

## Why It's Good For The Game

Requested
