### PR TITLE
SUCKING LANGUAGE FROM UR SKULL (Removes Infernal From Tiletian)

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
@@ -90,8 +90,7 @@
 		/datum/body_marking/facepaint
 	)
 	languages = list(
-		/datum/language/common,
-		/datum/language/hellspeak,
+		/datum/language/common
 	)
 	stress_examine = TRUE
 	stress_desc = span_red("Alchemical freak!")


### PR DESCRIPTION
## About The Pull Request

Removes infernal from tiletians. They're chemical homunculi rather than hellspawn, they shouldnt have the language

## Testing Evidence

Tested on a local host, forgot to record

## Why It's Good For The Game

Brings tiletians more in line with lore.
