### PR TITLE
Gives Risvonians and Perserdunians heavy leather boots instead of dark boots

### DIFF
--- a/code/modules/jobs/job_types/roguetown/perserdunian/ammosquire.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/ammosquire.dm
@@ -36,7 +36,7 @@
 
 /datum/outfit/job/roguetown/ammosquire/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
 	cloak = /obj/item/clothing/cloak/perserduntrenchcoat
 	pants = /obj/item/clothing/under/roguetown/trou/artipants

--- a/code/modules/jobs/job_types/roguetown/perserdunian/armsman.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/armsman.dm
@@ -36,7 +36,7 @@
 
 /datum/outfit/job/roguetown/armsman/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
 	cloak = /obj/item/clothing/cloak/perserduntrenchcoat
 	pants = /obj/item/clothing/under/roguetown/trou/artipants

--- a/code/modules/jobs/job_types/roguetown/perserdunian/auxiliar.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/auxiliar.dm
@@ -37,7 +37,7 @@
 
 /datum/outfit/job/roguetown/auxiliarist/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/leech
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	id = /obj/item/roguekey/perserdun
 	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light

--- a/code/modules/jobs/job_types/roguetown/perserdunian/blackguard.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/blackguard.dm
@@ -40,7 +40,7 @@
 
 /datum/outfit/job/roguetown/blackguard/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
 	cloak = /obj/item/clothing/cloak/blackguard

--- a/code/modules/jobs/job_types/roguetown/perserdunian/chirurgeon.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/chirurgeon.dm
@@ -37,7 +37,7 @@
 
 /datum/outfit/job/roguetown/chirurgeon/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	cloak = /obj/item/clothing/cloak/perserduntabard
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	belt = /obj/item/storage/belt/rogue/leather/black/soldier

--- a/code/modules/jobs/job_types/roguetown/perserdunian/envoy.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/envoy.dm
@@ -37,7 +37,7 @@
 
 /datum/outfit/job/roguetown/envoy/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/envoy
 	cloak = /obj/item/clothing/cloak/envoy
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants

--- a/code/modules/jobs/job_types/roguetown/perserdunian/grandmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/grandmaster.dm
@@ -39,7 +39,7 @@
 /datum/outfit/job/roguetown/grandmaster/pre_equip(mob/living/carbon/human/H)
 	H.verbs += /mob/living/carbon/human/proc/grandmaster_raid
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/grandmaster
 	pants = /obj/item/clothing/under/roguetown/trou/artipants
 	head = /obj/item/clothing/head/roguetown/helmet/leather/grandmaster

--- a/code/modules/jobs/job_types/roguetown/perserdunian/knightcommander.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/knightcommander.dm
@@ -36,7 +36,7 @@
 
 /datum/outfit/job/roguetown/knightcommander/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/hauberk
 	cloak = /obj/item/clothing/cloak/perserduntabard

--- a/code/modules/jobs/job_types/roguetown/perserdunian/partisan.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/partisan.dm
@@ -37,7 +37,7 @@
 
 /datum/outfit/job/roguetown/partisan/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	cloak = /obj/item/clothing/cloak/perserduntabard
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	belt = /obj/item/storage/belt/rogue/leather/black/soldier

--- a/code/modules/jobs/job_types/roguetown/perserdunian/radiotrooper.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/radiotrooper.dm
@@ -37,7 +37,7 @@
 
 /datum/outfit/job/roguetown/radiotrooper/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/radio
 	pants = /obj/item/clothing/under/roguetown/trou/artipants

--- a/code/modules/jobs/job_types/roguetown/perserdunian/rook.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/rook.dm
@@ -36,7 +36,7 @@
 
 /datum/outfit/job/roguetown/rook/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
 	cloak = /obj/item/clothing/cloak/perserduntrenchcoat
 	pants = /obj/item/clothing/under/roguetown/trou/artipants

--- a/code/modules/jobs/job_types/roguetown/perserdunian/voltigeur.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/voltigeur.dm
@@ -38,7 +38,7 @@
 
 /datum/outfit/job/roguetown/voltigeur/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	armor = /obj/item/clothing/suit/roguetown/armor/brigandine
 	cloak = /obj/item/clothing/cloak/perserduntrenchcoat/voltigeur
 	pants = /obj/item/clothing/under/roguetown/trou/artipants

--- a/code/modules/jobs/job_types/roguetown/perserdunian/warpriest.dm
+++ b/code/modules/jobs/job_types/roguetown/perserdunian/warpriest.dm
@@ -42,7 +42,7 @@
 
 /datum/outfit/job/roguetown/warpriest/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/priest/warpriest
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	beltl = /obj/item/gun/ballistic/revolver/mercy
 	beltr = /obj/item/flashlight/flare/torch/lantern
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/warpriest

--- a/code/modules/jobs/job_types/roguetown/risvonian/campfollower.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/campfollower.dm
@@ -37,7 +37,7 @@
 
 /datum/outfit/job/roguetown/campfollower/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	cloak = /obj/item/clothing/cloak/templar/malumite
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	belt = /obj/item/storage/belt/rogue/leather/black

--- a/code/modules/jobs/job_types/roguetown/risvonian/consulo.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/consulo.dm
@@ -39,7 +39,7 @@
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/consulo
 	cloak = /obj/item/clothing/cloak/templar/malumite
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	belt = /obj/item/storage/belt/rogue/leather/black/soldier
 	beltl = /obj/item/flashlight/flare/torch/lantern

--- a/code/modules/jobs/job_types/roguetown/risvonian/curacisto.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/curacisto.dm
@@ -37,7 +37,7 @@
 
 /datum/outfit/job/roguetown/curacisto/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	cloak = /obj/item/clothing/cloak/rismedtabard
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	belt = /obj/item/storage/belt/rogue/leather/black/soldier

--- a/code/modules/jobs/job_types/roguetown/risvonian/kaspafisto.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/kaspafisto.dm
@@ -37,7 +37,7 @@
 
 /datum/outfit/job/roguetown/kaspafisto/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
 	cloak = /obj/item/clothing/cloak/poncho
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants

--- a/code/modules/jobs/job_types/roguetown/risvonian/mulo.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/mulo.dm
@@ -39,7 +39,7 @@
 
 /datum/outfit/job/roguetown/mulo/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron/ziggurate
 	cloak = /obj/item/clothing/cloak/templar/malumite
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants

--- a/code/modules/jobs/job_types/roguetown/risvonian/pafanto.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/pafanto.dm
@@ -40,7 +40,7 @@
 
 /datum/outfit/job/roguetown/pafanto/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron/ziggurate
 	cloak = /obj/item/clothing/cloak/templar/malumite
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants

--- a/code/modules/jobs/job_types/roguetown/risvonian/servisto.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/servisto.dm
@@ -36,7 +36,7 @@
     
 /datum/outfit/job/roguetown/servisto/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron/ziggurate
 	cloak = /obj/item/clothing/cloak/rismedtabard
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants

--- a/code/modules/jobs/job_types/roguetown/risvonian/soldato.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/soldato.dm
@@ -39,7 +39,7 @@
 
 /datum/outfit/job/roguetown/soldato/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron/ziggurate
 	cloak = /obj/item/clothing/cloak/templar/malumite
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants

--- a/code/modules/jobs/job_types/roguetown/risvonian/tuoro.dm
+++ b/code/modules/jobs/job_types/roguetown/risvonian/tuoro.dm
@@ -37,7 +37,7 @@
 
 /datum/outfit/job/roguetown/tuoro/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron/ziggurate
 	cloak = /obj/item/clothing/cloak/templar/malumite
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants


### PR DESCRIPTION
## About The Pull Request

What it does on the tin, swaps the dark boots for the heavy leather boots on risvon and perserdun sides.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Spawned in as Persie, spawned in as Risvon, they both had the boots.

<img width="425" height="692" alt="image" src="https://github.com/user-attachments/assets/bf076dd9-2393-4daf-a60e-540419d44544" />

<img width="421" height="693" alt="image" src="https://github.com/user-attachments/assets/c0f7b481-1417-4760-9e98-3ab5e828e4fb" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Gives some sort of protection for the feet as a stopgap against the aim foot meta, heavy leather boots also look nicer and are thighboots which are sexy.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
