### PR TITLE
Makes it so plants dont update every tick anymore

### DIFF
--- a/code/modules/farming/soil.dm
+++ b/code/modules/farming/soil.dm
@@ -42,6 +42,8 @@
 	var/soil_decay_time = SOIL_DECAY_TIME
 	///The time remaining in which the soil was given special fertilizer, effect is similar to being blessed but with less beneficial effects
 	var/fertilized_time = 0
+	///Cached var to determine whether we need to call an icon update or not.
+	var/needs_icon_update = FALSE
 
 /obj/structure/soil/Crossed(atom/movable/AM)
 	. = ..()
@@ -286,6 +288,7 @@
 	if(plant && plant_dead)
 		plant_dead = FALSE
 		plant_health = 10.0
+		update_icon()
 	// If low on nutrition, Dendor provides
 	if(nutrition < 30)
 		adjust_nutrition(max(30 - nutrition, 0))
@@ -300,25 +303,33 @@
 	fertilized_time = 60 MINUTES //Keeps the plant fertilized for a good while
 
 /obj/structure/soil/proc/adjust_water(adjust_amount)
+	var/pre_water = water
 	water = clamp(water + adjust_amount, 0, MAX_PLANT_WATER)
-	update_icon()
+	if (adjust_amount && pre_water != water)
+		needs_icon_update = TRUE
 
 /obj/structure/soil/proc/adjust_nutrition(adjust_amount)
+	var/pre_nutrition = nutrition
 	nutrition = clamp(nutrition + adjust_amount, 0, MAX_PLANT_NUTRITION)
-	update_icon()
+	if (adjust_amount && pre_nutrition != nutrition)
+		needs_icon_update = TRUE
 
 /obj/structure/soil/proc/adjust_weeds(adjust_amount)
+	var/pre_weeds = weeds
 	weeds = clamp(weeds + adjust_amount, 0, MAX_PLANT_WEEDS)
-	update_icon()
+	if (adjust_amount && pre_weeds != weeds)
+		needs_icon_update = TRUE
 
 /obj/structure/soil/proc/adjust_plant_health(adjust_amount)
 	if(!plant || plant_dead)
 		return
+	var/pre_plant_health = plant_health
 	plant_health = clamp(plant_health + adjust_amount, 0, MAX_PLANT_HEALTH)
 	if(plant_health <= 0)
 		plant_dead = TRUE
 		produce_ready = FALSE
-	update_icon()
+	if (adjust_amount && pre_plant_health != plant_health)
+		needs_icon_update = TRUE
 
 /obj/structure/soil/Initialize()
 	START_PROCESSING(SSprocessing, src)
@@ -335,9 +346,11 @@
 	process_weeds(dt)
 	process_plant(dt)
 	process_soil(dt)
-	update_icon()
 	if(soil_decay_time <= 0)
 		decay_soil()
+	if (plant && needs_icon_update) // only call icon updates if we really need to (aka if we've requested an icon update and if we have a plant)
+		update_icon()
+		needs_icon_update = FALSE
 
 /obj/structure/soil/weather_act_on(weather_trait, severity)
 	if(weather_trait != PARTICLEWEATHER_RAIN)
@@ -578,11 +591,13 @@
 	if(!matured)
 		if(growth_time >= plant.maturation_time)
 			matured = TRUE
+			needs_icon_update = TRUE
 	else
 		produce_time += added_growth
 		if(produce_time >= plant.produce_time)
 			produce_time -= plant.produce_time
 			produce_ready = TRUE
+			needs_icon_update = TRUE
 
 
 #define SOIL_WATER_DECAY_RATE 0.5 / (1 MINUTES)


### PR DESCRIPTION
Added a cached variable to track icon updates for soil objects, optimizing icon update calls based on changes in water, nutrition, weeds, and plant health.

from 
https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1510/changes

## Why It's Good For The Game

no lag server as much
