### PR TITLE
Command Bar/Chat Bar toggle for admins, port from AP

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -761,6 +761,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	holder.deactivate()
 
 	to_chat(src, span_interface("I are now a normal player."))
+	hide_command_bar_button()
 	log_admin("[src] deadmined themself.")
 	message_admins("[src] deadmined themself.")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Deadmin")
@@ -786,6 +787,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 		return //This can happen if an admin attempts to vv themself into somebody elses's deadmin datum by getting ref via brute force
 
 	to_chat(src, span_interface("I am now an admin."))
+	show_command_bar_button()
 	message_admins("[src] re-adminned themselves.")
 	log_admin("[src] re-adminned themselves.")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Readmin")

--- a/code/modules/admin/verbs/toggle_command_bar.dm
+++ b/code/modules/admin/verbs/toggle_command_bar.dm
@@ -1,0 +1,40 @@
+/client/verb/toggle_command_bar_button()
+	set name = "toggle-command-bar-button"
+	set hidden = TRUE
+
+	if(!holder)
+		return
+
+	var/current = winget(src, "outputwindow.input", "command")
+	if(current == "say")
+		set_command_bar_mode(FALSE)
+	else
+		set_command_bar_mode(TRUE)
+
+/client/proc/set_command_bar_mode(say_mode = TRUE)
+	if(say_mode)
+		winset(src, "outputwindow.input", "command=say")
+		winset(src, "outputwindow.saybutton", "text=Say;is-checked=true")
+		to_chat(src, span_notice("Command bar set to <b>SAY</b> mode. All input goes to say."))
+	else
+		winset(src, "outputwindow.input", "command=")
+		winset(src, "outputwindow.saybutton", "text=Cmd;is-checked=false")
+		to_chat(src, span_notice("Command bar set to <b>COMMAND</b> mode. Type verbs directly (e.g. say, adminhelp, ooc)."))
+
+/client/proc/show_command_bar_button()
+	if(!holder)
+		return
+	winset(src, "outputwindow.saybutton", "is-visible=true")
+	winset(src, "outputwindow.input", "anchor2=92,100")
+
+/client/proc/hide_command_bar_button()
+	winset(src, "outputwindow.saybutton", "is-visible=false")
+	winset(src, "outputwindow.input", "anchor2=100,100")
+	set_command_bar_mode(TRUE)
+
+/client/proc/check_localhost_command_bar()
+	show_command_bar_button()
+	var/localhost_addresses = list("127.0.0.1", "::1")
+	if(isnull(address) || (address in localhost_addresses))
+		set_command_bar_mode(FALSE)
+		to_chat(src, span_notice("Localhost detected — command bar set to <b>COMMAND</b> mode automatically.")) 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -767,6 +767,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		if(isnull(address) || (address in localhost_addresses))
 			var/datum/admin_rank/localhost_rank = new("!localhost!", R_EVERYTHING, R_DBRANKS, R_EVERYTHING) //+EVERYTHING -DBRANKS *EVERYTHING
 			new /datum/admins(localhost_rank, ckey, 1, 1)
+			check_localhost_command_bar()
 	//preferences datum - also holds some persistent data for the client (because we may as well keep these datums to a minimum)
 	prefs = GLOB.preferences_datums[ckey]
 	if(prefs)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -135,7 +135,23 @@ window "outputwindow"
 		border = sunken
 		saved-params = ""
 		command = "say"
-
+	elem "saybutton"
+		type = BUTTON
+		pos = 590,445
+		size = 50x25
+		anchor1 = 100,100
+		anchor2 = 100,100
+		font-family = "Arial"
+		font-size = 9
+		font-style = "bold"
+		text-color = #ad9eb4
+		background-color = #1a1a1a
+		border = raised
+		saved-params = "is-checked"
+		text = "Say"
+		command = "toggle-command-bar-button"
+		is-visible = false
+		button-type = pushbox
 window "statwindow"
 	elem "statwindow"
 		type = MAIN

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1167,6 +1167,7 @@
 #include "code\modules\admin\verbs\randomverbs.dm"
 #include "code\modules\admin\verbs\reestablish_db_connection.dm"
 #include "code\modules\admin\verbs\schizohelp.dm"
+#include "code\modules\admin\verbs\toggle_command_bar.dm"
 #include "code\modules\admin\verbs\SDQL2\SDQL_2.dm"
 #include "code\modules\admin\verbs\SDQL2\SDQL_2_parser.dm"
 #include "code\modules\admin\verbs\SDQL2\SDQL_2_wrappers.dm"


### PR DESCRIPTION
## About The Pull Request

This makes it so admins can turn the chatbar into a command bar again, via a small button at the bottom right.

## Testing Evidence

<img width="1073" height="59" alt="grafik" src="https://github.com/user-attachments/assets/bfc2be82-fdfd-4eaa-b049-c84b040a943f" />


## Why It's Good For The Game
Makes it easier for admins if they are used to typing commands out. 
