### PR TITLE
Fixes get_real_price

### DIFF
--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -38,7 +38,8 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 
 /atom/movable/proc/get_real_price()
 	var/total_sellprice = 0
-	if(length(src.contents)) // this overrides the objects base price but 90% of usecases will not see someone trying to sell a full satchel.
+	if(length(src.contents))
+		total_sellprice = sellprice
 		for(var/obj/item/I in src.contents) // runs a loop on anytihng that's got contents under our current inv system
 			if(I) // runs the get_real_price recurisvely. please dont runtime.
 				total_sellprice += I.get_real_price()


### PR DESCRIPTION
## About The Pull Request

Originally get_real_price would ignore the price of the container if it was selling a container. This is an issue because guns are technically containers, so it'd ignore the guns sellprice and get the price of the fucking mag instead (nothing). This no longer happens, Kings Row rejoice.

## Testing Evidence

<img width="219" height="48" alt="image" src="https://github.com/user-attachments/assets/159ae7e7-3892-427e-a7e1-62b1b72160b5" />

## Why It's Good For The Game

Guns can now be sold. Economy is so back.
