### PR TITLE
Poison gas bugfix

### DIFF
--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -126,7 +126,7 @@
 
 /obj/effect/particle_effect/smoke/bad/smoke_mob(mob/living/carbon/M)
 	if(..())
-		if(!istype(M.wear_mask, /obj/item/clothing/mask/rogue/gasmask))
+		if(!istype(M.wear_mask, /obj/item/clothing/mask/rogue/gasmask) && !HAS_TRAIT(M, TRAIT_NOBREATH))
 			M.drop_all_held_items()
 			M.adjustOxyLoss(1)
 			M.emote("cough")
@@ -148,7 +148,7 @@
 
 /obj/effect/particle_effect/smoke/poison_gas/smoke_mob(mob/living/carbon/M)
 	if(..())
-		if(!istype(M.wear_mask, /obj/item/clothing/mask/rogue/gasmask))
+		if(!istype(M.wear_mask, /obj/item/clothing/mask/rogue/gasmask) && !HAS_TRAIT(M, TRAIT_NOBREATH))
 			M.adjustToxLoss(20, 0)
 			M.adjustFireLoss(20, 0)
 			M.emote("firescream")


### PR DESCRIPTION
## About The Pull Request

Poison gas now checks if you actually breath, not just for a mask.

## Testing Evidence

<img width="279" height="260" alt="image" src="https://github.com/user-attachments/assets/188f0b54-2076-48e2-b6fb-cc4eef597551" />

## Why It's Good For The Game

Fixes #254 
If I cant breath how is the gas killing me? Checkmate Rab.
