### PR TITLE
Fixes improper char setup window scaling

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -751,6 +751,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 		dat = list("<center>REGISTER!</center>")
 
 	winshow(user, "preferencess_window", TRUE)
+	winset(user, "preferencess_window", "size=700x700")
 	var/datum/browser/noclose/popup = new(user, "preferences_browser", "<div align='center'>[used_title]</div>")
 	popup.set_window_options("can_close=0")
 	popup.set_content(dat.Join())

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -184,7 +184,7 @@ window "preferencess_window"
 	elem "preferencess_window"
 		type = MAIN
 		pos = 372,150
-		size = 700x630
+		size = 700x700
 		anchor1 = -1,-1
 		anchor2 = -1,-1
 		is-visible = false
@@ -195,7 +195,7 @@ window "preferencess_window"
 	elem "preferences_browser"
 		type = BROWSER
 		pos = 0,0
-		size = 700x630
+		size = 700x700
 		anchor1 = 0,0
 		anchor2 = 75,100
 		saved-params = ""


### PR DESCRIPTION
before:
<img width="421" height="474" alt="image" src="https://github.com/user-attachments/assets/54fcd984-df82-415c-9569-1282c73f5798" />
after:
<img width="356" height="372" alt="image" src="https://github.com/user-attachments/assets/1e8483c5-095a-4e70-bd99-208b298e26c1" />