### PR TITLE
disables char minimums for ft/ooc notes

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -1,5 +1,5 @@
-#define MINIMUM_FLAVOR_TEXT		200
-#define MINIMUM_OOC_NOTES 		5 //Just put something in there
+#define MINIMUM_FLAVOR_TEXT		-1
+#define MINIMUM_OOC_NOTES 		-1
 
 
 //Preference toggles

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1705,7 +1705,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						dat += "<div align='center'><b>OOC notes</b></div>"
 						dat += "<div align='left'>[ooc_notes_display]</div>"
 					if(ooc_extra)
-						dat += "[ooc_extra]"
+						dat += "<div align='center'>[ooc_extra]</div>"
 					var/datum/browser/popup = new(user, "[real_name]", nwidth = 600, nheight = 800)
 					popup.set_content(dat.Join())
 					popup.open(FALSE)


### PR DESCRIPTION
## About The Pull Request

title
also makes ooc extras centered

## Testing Evidence

<img width="480" height="163" alt="image" src="https://github.com/user-attachments/assets/f736c592-cd86-4a19-886e-7112f1927280" />

## Why It's Good For The Game

these minimums are absolutely pointless
ooc extras look better when centered