### PR TITLE
Repairs broken CI workflow

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -70,8 +70,9 @@ jobs:
       
       - name: Install BYOND
         run: |
+          sudo dpkg --add-architecture i386
           sudo apt-get update -qq
-          sudo apt-get install -y make gcc unzip
+          sudo apt-get install -y make gcc unzip lib32z1 libc6:i386 libstdc++6:i386 libgcc-s1:i386 libcurl4:i386
           bash tools/ci/install_byond.sh
 
       - name: Compile BYOND project

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -17,7 +17,7 @@ export NODE_VERSION_LTS=22.11.0
 export BUN_VERSION=1.2.16
 
 # SpacemanDMM git tag
-export SPACEMAN_DMM_VERSION=suite-1.8
+export SPACEMAN_DMM_VERSION=suite-1.11
 
 # Python version for mapmerge and other tools
 export PYTHON_VERSION=3.10.0


### PR DESCRIPTION
## About The Pull Request

Updates the CI workflow to install the missing 32-bit runtime libraries required to build and run BYOND.
Also fixes linters by updating the outdated version of SpacemanDMM to support alists.

This is a bit of a bandaid solution — AP's CI workflow is way better (and in-line with modern TG's), and in an ideal world, we'd port that wholesale. But we won't, so at least this gets what we have working.