### PR TITLE
fixes various chair items' origin_type var

### DIFF
--- a/code/game/objects/structures/beds_chairs/roguechair.dm
+++ b/code/game/objects/structures/beds_chairs/roguechair.dm
@@ -469,6 +469,7 @@
 
 /obj/item/chair/rogue/generic1
 	icon_state = "genericchair"
+	origin_type = /obj/structure/chair/wood/rogue/generic1
 
 /obj/structure/chair/wood/rogue/generic2
 	icon_state = "genericchair2"
@@ -480,6 +481,7 @@
 
 /obj/item/chair/rogue/generic2
 	icon_state = "genericchair2"
+	origin_type = /obj/structure/chair/wood/rogue/generic2
 
 /obj/structure/chair/wood/rogue/fancy1
 	icon_state = "fancychair"
@@ -491,6 +493,7 @@
 
 /obj/item/chair/rogue/fancychair
 	icon_state = "fancychair"
+	origin_type = /obj/structure/chair/wood/rogue/fancy1
 
 /obj/structure/chair/wood/rogue/fancychair2
 	icon_state = "fancychair2"
@@ -502,6 +505,7 @@
 
 /obj/item/chair/rogue/fancychair2
 	icon_state = "fancychair2"
+	origin_type = /obj/structure/chair/wood/rogue/fancychair2
 
 /obj/structure/bed/rogue/oldcomfy
 	name = "old bed"


### PR DESCRIPTION
## About The Pull Request

Makes it so if you knock down chairs and put them back they dont shapeshift

## Testing Evidence

<img width="255" height="270" alt="image" src="https://github.com/user-attachments/assets/d85e00c0-a740-48a6-b171-b59801c6b044" />

<img width="216" height="162" alt="image" src="https://github.com/user-attachments/assets/329d7b52-9ab2-4e83-a2a5-9f292b1bf515" />

<img width="196" height="227" alt="image" src="https://github.com/user-attachments/assets/1d4fafd4-970a-4d24-ad88-6f9ab0c1f929" />

## Why It's Good For The Game

Chairs should not shapeshift
