### PR TITLE
Better Ghosting

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -567,16 +567,17 @@ GLOBAL_LIST_EMPTY(species_list)
 			var/rendered_message = message
 
 			if(follow_target)
-//				var/F
-//				if(turf_target)
-//					F = FOLLOW_OR_TURF_LINK(M, follow_target, turf_target)
-//				else
-//					F = FOLLOW_LINK(M, follow_target)
-//				rendered_message = "[F] [message]"
-				rendered_message = "[message]"
+				var/F
+				if(turf_target)
+					F = FOLLOW_OR_TURF_LINK(M, follow_target, turf_target)
+				else
+					F = FOLLOW_LINK(M, follow_target)
+				rendered_message = "[F] [message]"
+//				rendered_message = "[message]"
 			else if(turf_target)
-//				var/turf_link = TURF_LINK(M, turf_target)
-//				rendered_message = "[turf_link] [message]"
+				var/turf_link = TURF_LINK(M, turf_target)
+				rendered_message = "[turf_link] [message]"
+			else
 				rendered_message = "[message]"
 
 			to_chat(M, rendered_message)

--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -9,6 +9,7 @@ GLOBAL_VAR_INIT(changelog_hash, "")
 GLOBAL_VAR_INIT(hub_visibility, FALSE)
 
 GLOBAL_VAR_INIT(ooc_allowed, TRUE)	// used with admin verbs to disable ooc - not a config option apparently
+GLOBAL_VAR_INIT(deadchat_allowed, TRUE) //ditto for disabling deadchat
 GLOBAL_VAR_INIT(dooc_allowed, TRUE)
 GLOBAL_VAR_INIT(enter_allowed, TRUE)
 GLOBAL_VAR_INIT(shuttle_frozen, FALSE)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -500,6 +500,15 @@
 	message_admins("[key_name_admin(usr)] toggled Dead OOC.")
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Dead OOC", "[GLOB.dooc_allowed ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/datum/admins/proc/toggledeadchat()
+	set category = "-Server-"
+	set desc="For when the salt is too much."
+	set name="Toggle Deadchat"
+	toggle_deadchat()
+	log_admin("[key_name(usr)] toggled Deadchat.")
+	message_admins("[key_name_admin(usr)] toggled Deadchat.")
+	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Deadchat", "[GLOB.deadchat_allowed ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /datum/admins/proc/startnow()
 	set category = "-Server-"
 	set desc="Start the round RIGHT NOW"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -72,6 +72,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/client/proc/game_panel,			/*game panel, allows to change game-mode etc*/
 	/datum/admins/proc/toggleooc,		/*toggles ooc on/off for everyone*/
 	/datum/admins/proc/toggleoocdead,	/*toggles ooc on/off for everyone who is dead*/
+	/datum/admins/proc/toggledeadchat, /*toggles deadchat on/off for everyone*/
 	/datum/admins/proc/toggleenter,		/*toggles whether people can join the current game*/
 	/datum/admins/proc/toggleguests,	/*toggles whether guests can join the current game*/
 	/datum/admins/proc/announce,		/*priority announce something to all clients.*/

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -41,3 +41,13 @@
 		return
 
 	dsay(msg)
+
+/proc/toggle_deadchat(toggle = null)
+	if(toggle != null) //if we're specifically en/disabling ooc
+		if(toggle != GLOB.deadchat_allowed)
+			GLOB.deadchat_allowed = toggle
+		else
+			return
+	else //otherwise just toggle it
+		GLOB.deadchat_allowed = !GLOB.deadchat_allowed
+	message_admins("<B>Deadchat has been globally [GLOB.deadchat_allowed ? "enabled" : "disabled"].</B>")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -138,21 +138,11 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 				T = get_turf(Y)
 
 		gender = body.gender
-		if(body.mind && body.mind.name)
-			if(body.mind.ghostname)
-				name = body.mind.ghostname
-			else
-				name = body.mind.name
-		else
-			if(body.real_name)
-				name = body.real_name
-			else
-				name = random_unique_name(gender)
+
 
 		mind = body.mind	//we don't transfer the mind but we keep a reference to it.
 
 		set_suicide(body.suiciding) // Transfer whether they committed suicide.
-
 		if(draw_icon)
 			if(ishuman(body))
 //				var/mob/living/carbon/human/body_human = body
@@ -181,14 +171,21 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 				facial_hairstyle = body_human.facial_hairstyle
 				facial_hair_color = brighten_color(body_human.facial_hair_color)
 			*/
+		if(body.mind && body.mind.name)
+			if(body.mind.ghostname)
+				name = body.mind.ghostname
+			else if(body.real_name && body.real_name != "Unknown")
+				name = body.real_name
+			else if(body.name && body.name != "Unknown")
+				name = body.mind.name
+			else
+				name = random_unique_name(gender)
 	update_icon()
-
 	if(!T)
 		testing("NO T")
 		T = SSmapping.get_station_center()
 
 	forceMove(T)
-
 	if(!name)							//To prevent nameless ghosts
 		name = random_unique_name(gender)
 	real_name = name

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -67,6 +67,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	var/next_gmove
 	var/misting = 0
 	draw_icon = TRUE
+	hud_type = /datum/hud/adminghost //as far as i can tell it's fine if players have this
 
 /mob/dead/observer/admin
 	hud_type = /datum/hud/adminghost
@@ -80,7 +81,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 /mob/dead/observer/rogue/Move(n, direct)
 	if(world.time < next_gmove)
 		return
-	next_gmove = world.time + 2
+	next_gmove = world.time + 1
 
 	setDir(direct)
 
@@ -578,8 +579,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Teleport"
 	set desc= "Teleport to a location"
 	set hidden = 1
-	if(!check_rights(R_WATCH))
-		return
+/*	if(!check_rights(R_WATCH))
+		return*/
 	if(!isobserver(usr))
 		to_chat(usr, span_warning("Not when you're not dead!"))
 		return

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -25,11 +25,11 @@
 
 	. = say_dead(message)
 
-/mob/dead/observer/rogue/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
-	return
+///mob/dead/observer/rogue/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
+//	return
 
-/mob/dead/observer/rogue/say_dead(message)
-	return
+///mob/dead/observer/rogue/say_dead(message)
+//	return
 
 /mob/dead/observer/screye/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	return

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -93,11 +93,11 @@
 	unset_machine()
 	timeofdeath = world.time
 	tod = station_time_timestamp()
-//	var/turf/T = get_turf(src)
+	var/turf/T = get_turf(src)
 	for(var/obj/item/I in contents)
 		I.on_mob_death(src, gibbed)
-//	if(mind && mind.name && mind.active && !istype(T.loc, /area/ctf))
-//		deadchat_broadcast(" has died at <b>[get_area_name(T)]</b>.", "<b>[mind.name]</b>", follow_target = src, turf_target = T, message_type=DEADCHAT_DEATHRATTLE)
+	if(mind && mind.name && mind.active && !istype(T.loc, /area/ctf))
+		deadchat_broadcast(" has died at <b>[get_area_name(T)]</b>.", "<b>[mind.name]</b>", follow_target = src, turf_target = T, message_type=DEADCHAT_DEATHRATTLE)
 //	if(mind)
 //		mind.store_memory("Time of death: [tod]", 0)
 	GLOB.alive_mob_list -= src

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -118,8 +118,14 @@
 ///Speak as a dead person (ghost etc)
 /mob/proc/say_dead(message)
 	var/turf/T = get_turf(src)
+	if(src.client.prefs.muted & MUTE_DEADCHAT)
+		to_chat(src, span_danger("I cannot use Deadchat (temp muted)."))
+		return
 	if(is_banned_from(src.ckey, "Deadchat"))
-		to_chat(src, span_danger("My voice has been stripped by Rab. I cannot speak."))
+		to_chat(src, span_danger("I cannot use Deadchat (perma muted)."))
+		return
+	if(!GLOB.deadchat_allowed)
+		to_chat(src, span_danger("Deadchat is currently disabled."))
 		return
 	deadchat_broadcast(" says, \"[message]\"", "<b>[real_name]</b>", src, T, src.ckey, DEADCHAT_REGULAR)
 	return 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -118,6 +118,9 @@
 ///Speak as a dead person (ghost etc)
 /mob/proc/say_dead(message)
 	var/turf/T = get_turf(src)
+	if(is_banned_from(src.ckey, "Deadchat"))
+		to_chat(src, span_danger("My voice has been stripped by Rab. I cannot speak."))
+		return
 	deadchat_broadcast(" says, \"[message]\"", "<b>[real_name]</b>", src, T, src.ckey, DEADCHAT_REGULAR)
 	return 
 	//deadchat_broadcast(" has died at <b>[get_area_name(T)]</b>.", "<b>[mind.name]</b>", follow_target = src, turf_target = T, message_type=DEADCHAT_DEATHRATTLE)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -117,8 +117,10 @@
 
 ///Speak as a dead person (ghost etc)
 /mob/proc/say_dead(message)
-
-	return // RTCHANGE
+	var/turf/T = get_turf(src)
+	deadchat_broadcast(" says, \"[message]\"", "<b>[real_name]</b>", src, T, src.ckey, DEADCHAT_REGULAR)
+	return 
+	//deadchat_broadcast(" has died at <b>[get_area_name(T)]</b>.", "<b>[mind.name]</b>", follow_target = src, turf_target = T, message_type=DEADCHAT_DEATHRATTLE)
 
 ///Check if this message is an emote
 /mob/proc/check_emote(message, forced)


### PR DESCRIPTION
## About The Pull Request
Gives players access to the same stuff aghost has- jumping, orbiting, etc. Also adds deadchat, along with the ability to toggle deadchat as a whole as an admin.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I successfully tested
-Deadchat shows to yourself
-When you die, it shows up in deadchat
-There are links on deadchat messages to jump to whoever was speaking
-Being individually temp-muted from deadchat
-Globally muting deadchat as an admin
-Most of the ghost verbs as a non-admin

I was unable to test
-Any interactions between living and dead people with deadchat
-Show/hide deadchat while alive as an admin
-If dead people can hear other dead people
-Orbit verbs as a non-admin
-If death has a 'jump to' message
-Probably more I'm forgetting

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Being dead is PROFOUNDLY unpleasant. This way, players can still observe and comment on the round after their deaths- giving them something to do while waiting for the poor first time leech buried in a dozen bodies to make their way through to reviving them.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
